### PR TITLE
add route input to kui-search

### DIFF
--- a/projects/knora/search/package.json
+++ b/projects/knora/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knora/search",
-  "version": "1.0.0-alpha",
+  "version": "1.0.3-alpha",
   "description": "Knora ui module",
   "repository": {
     "type": "git",

--- a/projects/knora/search/src/lib/extended-search/extended-search.component.ts
+++ b/projects/knora/search/src/lib/extended-search/extended-search.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Inject, OnInit, Output, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { Component, EventEmitter, Inject, Input, OnInit, Output, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import {
@@ -21,6 +21,8 @@ import { SelectResourceClassComponent } from './select-resource-class/select-res
     styleUrls: ['./extended-search.component.scss']
 })
 export class ExtendedSearchComponent implements OnInit {
+
+    @Input() route;
 
     // trigger toggle for extended search form
     @Output() toggleExtendedSearchForm = new EventEmitter<boolean>();
@@ -203,7 +205,7 @@ export class ExtendedSearchComponent implements OnInit {
 
         const gravsearch = this._gravSearchService.createGravsearchQuery(properties, resClass, 0);
 
-        this._router.navigate(['extended/', gravsearch], { relativeTo: this._route });
+        this._router.navigate([this.route + '/extended/', gravsearch], { relativeTo: this._route });
 
         // toggle extended search form
         this.toggleExtendedSearchForm.emit(true);

--- a/projects/knora/search/src/lib/search.component.html
+++ b/projects/knora/search/src/lib/search.component.html
@@ -49,7 +49,7 @@
                 </span>
             </div>
             <div class="extended-search-box">
-                <kui-extended-search (toggleExtendedSearchForm)="toggleMenu('extendedSearch')"></kui-extended-search>
+                <kui-extended-search [route]="route" (toggleExtendedSearchForm)="toggleMenu('extendedSearch')"></kui-extended-search>
             </div>
         </div>
     </div>

--- a/projects/knora/search/src/lib/search.component.ts
+++ b/projects/knora/search/src/lib/search.component.ts
@@ -12,7 +12,7 @@
  * License along with SALSAH.  If not, see <http://www.gnu.org/licenses/>.
  * */
 
-import { Component, ElementRef, OnInit } from '@angular/core';
+import { Component, ElementRef, Input, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import {
     animate,
@@ -48,6 +48,8 @@ import {
 
 
 export class SearchComponent implements OnInit {
+
+    @Input() route: string = '/search';
 
     searchQuery: string;
 
@@ -94,7 +96,7 @@ export class SearchComponent implements OnInit {
     doSearch(search_ele: HTMLElement): void {
         if (this.searchQuery !== undefined && this.searchQuery !== null) {
             this.toggleMenu('simpleSearch');
-            this._router.navigate(['/modules/search/fulltext/' + this.searchQuery]);
+            this._router.navigate([this.route + '/fulltext/' + this.searchQuery]);
 
             // this._router.navigate(['/search/fulltext/' + this.searchQuery], { relativeTo: this._route });
 
@@ -136,7 +138,7 @@ export class SearchComponent implements OnInit {
      */
     doPrevSearch(query: string): void {
         this.searchQuery = query;
-        this._router.navigate(['/modules/search/fulltext/' + query], { relativeTo: this._route });
+        this._router.navigate([this.route + '/fulltext/' + query], { relativeTo: this._route });
         this.toggleMenu('simpleSearch');
     }
 

--- a/src/app/knora-ui-examples/search-demo/search-demo.component.html
+++ b/src/app/knora-ui-examples/search-demo/search-demo.component.html
@@ -1,5 +1,5 @@
 <app-module-header [demo]="partOf"></app-module-header>
 
-<kui-search></kui-search>
+<kui-search [route]="'/modules/search'"></kui-search>
 
 <router-outlet></router-outlet>


### PR DESCRIPTION
If someone wants to use @knora/search module with <kui-search> he can define a route, where the search results should be displayed. e.g. <kui-search [route]="'/search'"></kui-search>