### PR TITLE
interface AutoCompleteItem

### DIFF
--- a/projects/knora/core/src/lib/declarations/api/operators.ts
+++ b/projects/knora/core/src/lib/declarations/api/operators.ts
@@ -272,3 +272,13 @@ export class PropertyWithValue {
 
 }
 
+/**
+ * a list, which is used in the mat-autocomplete form field
+ * contains objects with id and name. the id is usual the iri
+ */
+export interface AutocompleteItem {
+    iri: string;
+    name: string;
+    label?: string;
+}
+


### PR DESCRIPTION
Move the interface AutoCompleteItem into operators.ts from Salsah.

resolves #62 