### PR TITLE
fix (core module): fix date

### DIFF
--- a/projects/knora/core/package.json
+++ b/projects/knora/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knora/core",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.7",
   "description": "Knora ui module",
   "repository": {
     "type": "git",

--- a/projects/knora/core/src/lib/declarations/api/shared/date.ts
+++ b/projects/knora/core/src/lib/declarations/api/shared/date.ts
@@ -8,7 +8,7 @@ import { JsonObject, JsonProperty } from 'json2typescript';
 export class DateFormatSalsah {
 
     @JsonProperty('date', Date)
-    public date: Date = undefined;
+    public date: Date = new Date();
 
     @JsonProperty('format', String)
     public format: string = undefined;

--- a/projects/knora/core/src/lib/declarations/api/v2/properties/read-property-item.ts
+++ b/projects/knora/core/src/lib/declarations/api/v2/properties/read-property-item.ts
@@ -163,7 +163,7 @@ export class ReadDateValue implements ReadPropertyItem {
 
     readonly type = KnoraConstants.DateValue;
 
-    private separator = ', ';
+    private separator = '/';
 
 
     getDate(): DateSalsah {

--- a/projects/knora/core/src/lib/declarations/api/v2/properties/read-property-item.ts
+++ b/projects/knora/core/src/lib/declarations/api/v2/properties/read-property-item.ts
@@ -163,7 +163,7 @@ export class ReadDateValue implements ReadPropertyItem {
 
     readonly type = KnoraConstants.DateValue;
 
-    private separator = '-';
+    private separator = ', ';
 
 
     getDate(): DateSalsah {


### PR DESCRIPTION
This PR resolves the issue with the date pipe in Safari.
resolves #95 

Here we found the solution:
https://stackoverflow.com/questions/49725663/wrong-safari-date-using-typescript-angular-4

And here's the discussion on Angular about this "bug":
https://github.com/angular/angular/issues/12334

The solution was: replace '-' with '/' in date string; instead of `2018-10-27` we have to use `2018/10/27` as a value inside of `new Date();`