### PR TITLE
Core module: fix month precision date

### DIFF
--- a/projects/knora/core/package.json
+++ b/projects/knora/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knora/core",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "Knora ui module",
   "repository": {
     "type": "git",

--- a/projects/knora/core/src/lib/declarations/api/v2/properties/read-property-item.ts
+++ b/projects/knora/core/src/lib/declarations/api/v2/properties/read-property-item.ts
@@ -181,7 +181,7 @@ export class ReadDateValue implements ReadPropertyItem {
             startPrecision = 'yyyy';
         } else if (this.startDay === undefined) {
             // month precision
-            startDate = this.startYear + this.separator + this.startMonth;
+            startDate = this.startYear + this.separator + this.startMonth + this.separator + 1;
             startPrecision = 'MMMM ' + 'yyyy';
         } else {
             // day precision
@@ -200,7 +200,7 @@ export class ReadDateValue implements ReadPropertyItem {
             endPrecision = 'yyyy';
         } else if (this.endDay === undefined) {
             // month precision
-            endDate = this.endYear + this.separator + this.endMonth;
+            endDate = this.endYear + this.separator + this.endMonth + this.separator + 1;
             endPrecision = 'MMMM ' + 'yyyy';
         } else {
             // day precision


### PR DESCRIPTION
The date format month/year is considered as invalid date format by Safari and Firefox > need to add a default day but the template format remains the same.