### PR TITLE
Viewer: add test for string containing special chars in HTML

### DIFF
--- a/projects/knora/viewer/src/lib/property/text-value/text-value-as-string/text-value-as-string.component.spec.ts
+++ b/projects/knora/viewer/src/lib/property/text-value/text-value-as-string/text-value-as-string.component.spec.ts
@@ -62,6 +62,26 @@ describe('TextValueAsStringComponent', () => {
         expect(spanNativeElement.innerText).toEqual('Natural Science');
     });
 
+    it('should handle special characters in HTML correctly', () => {
+
+        testHostComponent.stringValue = new ReadTextValueAsString('id', 'propIri', '<>&\'"');
+
+        testHostFixture.detectChanges();
+
+        const hostCompDe = testHostFixture.debugElement;
+
+        const stringVal = hostCompDe.query(By.directive(TextValueAsStringComponent));
+
+        const spanDebugElement: DebugElement = stringVal.query(By.css('span'));
+
+        const spanNativeElement: HTMLElement = spanDebugElement.nativeElement;
+
+        expect(spanNativeElement.innerText).toEqual('<>&\'"');
+
+        expect(spanNativeElement.innerHTML).toEqual('&lt;&gt;&amp;\'"');
+
+    });
+
 });
 
 


### PR DESCRIPTION
This PR adds a test checking for the correct handling of special chars in HTML for a string value (no markup).

relates to https://github.com/dhlab-basel/beol/issues/52
relates to https://github.com/dhlab-basel/Knora/issues/1105
closes #138