### PR TITLE
Core (admin): get old methods in usersService back

### DIFF
--- a/projects/knora/authentication/src/lib/session/session.service.ts
+++ b/projects/knora/authentication/src/lib/session/session.service.ts
@@ -53,7 +53,7 @@ export class SessionService {
                 this.session = {
                     id: this.setTimestamp(),
                     user: {
-                        name: username,
+                        name: result.username,
                         jwt: jwt,
                         lang: result.lang,
                         sysAdmin: sysAdmin

--- a/projects/knora/core/src/lib/services/admin/users.service.ts
+++ b/projects/knora/core/src/lib/services/admin/users.service.ts
@@ -47,6 +47,30 @@ export class UsersService extends ApiService {
         );
     }
 
+    /**
+     * Deprecated! Please use getUser(identifier: string) only!
+     * Get user by email
+     *
+     * @ignore
+     *
+     * @param {string} email
+     * @returns {Observable<User>}
+     */
+    getUserByEmail(email: string): Observable<User> {
+        return this.getUser(email);
+    }
+
+    /**
+     * Deprecated! Please use getUser(identifier: string) only!
+     *
+     * @ignore
+     *
+     * @param {string} iri
+     * @returns {Observable<User>}
+     */
+    getUserByIri(iri: string): Observable<User> {
+        return this.getUser(iri);
+    }
 
     // ------------------------------------------------------------------------
     // POST


### PR DESCRIPTION
We had two methods to get a user object: getUserByEmail and getUserByIri. After a breaking change in knora, we didn't need those method anymore and I deleted them. But some apps implemented these methods and I had to put them back, but I marked them as "deprecated" and we will remove them in the next release (7.x.x). Then we only need one method: getUser(iri || email || username)