### PR TITLE
Core: remove fdescribe from test

### DIFF
--- a/projects/knora/core/src/lib/services/v2/search-params.service.spec.ts
+++ b/projects/knora/core/src/lib/services/v2/search-params.service.spec.ts
@@ -4,7 +4,7 @@ import { HttpClient } from '@angular/common/http';
 
 import { ExtendedSearchParams, SearchParamsService } from './search-params.service';
 
-fdescribe('SearchParamsService', () => {
+describe('SearchParamsService', () => {
     let searchParamsService: SearchParamsService;
 
     beforeEach(() => {


### PR DESCRIPTION
By mistake, `fdescribe` was merged to the master branch.