### PR TITLE
fix (viewer): remove SVG overlays from DOM

### DIFF
--- a/projects/knora/viewer/src/lib/resource/still-image/still-image.component.ts
+++ b/projects/knora/viewer/src/lib/resource/still-image/still-image.component.ts
@@ -334,6 +334,8 @@ export class StillImageComponent implements OnInit, OnChanges, OnDestroy {
             }
         }
 
+        this.regions = {};
+
         // TODO: make this work by using osdviewer's addOverlay method
         this.viewer.clearOverlays();
     }
@@ -344,8 +346,6 @@ export class StillImageComponent implements OnInit, OnChanges, OnDestroy {
     private renderRegions(): void {
 
         this.removeOverlays();
-
-        this.regions = {};
 
         let imageXOffset = 0; // see documentation in this.openImages() for the usage of imageXOffset
 

--- a/projects/knora/viewer/src/lib/resource/still-image/still-image.component.ts
+++ b/projects/knora/viewer/src/lib/resource/still-image/still-image.component.ts
@@ -315,15 +315,36 @@ export class StillImageComponent implements OnInit, OnChanges, OnDestroy {
         // display only the defined range of this.images
         const tileSources: Object[] = StillImageComponent.prepareTileSourcesFromFileValues(fileValues);
 
-        this.viewer.clearOverlays();
+        this.removeOverlays();
         this.viewer.open(tileSources);
+    }
+
+    /**
+     * Removes SVG overlays from the DOM.
+     */
+    private removeOverlays() {
+
+        for (const reg in this.regions) {
+            if (this.regions.hasOwnProperty(reg)) {
+                for (const pol of this.regions[reg]) {
+                    if (pol instanceof SVGPolygonElement) {
+                        pol.remove();
+                    }
+                }
+            }
+        }
+
+        // TODO: make this work by using osdviewer's addOverlay method
+        this.viewer.clearOverlays();
     }
 
     /**
      * Adds a ROI-overlay to the viewer for every region of every image in this.images
      */
     private renderRegions(): void {
-        this.viewer.clearOverlays();
+
+        this.removeOverlays();
+
         this.regions = {};
 
         let imageXOffset = 0; // see documentation in this.openImages() for the usage of imageXOffset
@@ -428,7 +449,7 @@ export class StillImageComponent implements OnInit, OnChanges, OnDestroy {
         svgGroup.appendChild(svgElement);
 
         const overlay = this.viewer.svgOverlay();
-        overlay.node().appendChild(svgGroup);
+        overlay.node().appendChild(svgGroup); // TODO: use method osdviewer's method addOverlay
 
         this.regions[regionIri].push(svgElement);
     }


### PR DESCRIPTION
Clears overlays before redrawing them.

Currently, overlays are directly inserted into and removed from the DOM. ~~Instead, the methods of osdviewer should be used.~~ 

~~See https://openseadragon.github.io/docs/OpenSeadragon.Viewer.html#addOverlay for clean handling (`addOverlay`).~~

https://github.com/openseadragon/svg-overlay/issues/32#issuecomment-463297360

-> we use the SVG plugin, not the viewer's overlay system.