### PR TITLE
Restrict fulltext search to a project

### DIFF
--- a/projects/knora/core/src/lib/services/v2/search.service.spec.ts
+++ b/projects/knora/core/src/lib/services/v2/search.service.spec.ts
@@ -1,7 +1,7 @@
 import { async, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
-import {FulltextSearchParams, SearchService} from './search.service';
+import {FulltextSearchParams, SearchByLabelParams, SearchService} from './search.service';
 import { KuiCoreModule } from '../../core.module';
 import { ApiService } from '../api.service';
 import { OntologyCacheService, OntologyInformation, Properties, ResourceClasses } from './ontology-cache.service';
@@ -743,4 +743,26 @@ OFFSET 0`;
 
         httpRequest[0].flush(expectedResource);
     }));
+
+    it('should correctly handle "SearchByLabelParams"', () => {
+
+        let searchParams: SearchByLabelParams = {
+            limitToProject: 'http://rdfh.ch/projects/0001'
+        };
+
+        let httpParams = searchService['processSearchByLabelParams'](searchParams, new HttpParams());
+
+        expect(httpParams.get('limitToProject')).toEqual('http://rdfh.ch/projects/0001');
+        expect(httpParams.keys().length).toEqual(1);
+
+        searchParams = {
+            limitToResourceClass: 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing'
+        };
+
+        httpParams = searchService['processSearchByLabelParams'](searchParams, new HttpParams());
+
+        expect(httpParams.get('limitToResourceClass')).toEqual('http://0.0.0.0:3333/ontology/0001/anything/v2#Thing');
+        expect(httpParams.keys().length).toEqual(1);
+
+    });
 });

--- a/projects/knora/core/src/lib/services/v2/search.service.spec.ts
+++ b/projects/knora/core/src/lib/services/v2/search.service.spec.ts
@@ -1,12 +1,13 @@
 import { async, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
-import { SearchService } from './search.service';
+import {FulltextSearchParams, SearchService} from './search.service';
 import { KuiCoreModule } from '../../core.module';
 import { ApiService } from '../api.service';
 import { OntologyCacheService, OntologyInformation, Properties, ResourceClasses } from './ontology-cache.service';
 import { of } from 'rxjs';
 import { CountQueryResult } from '../../declarations';
+import {HttpParams} from '@angular/common/http';
 
 describe('SearchService', () => {
     let httpTestingController: HttpTestingController;
@@ -316,6 +317,37 @@ describe('SearchService', () => {
         httpRequest[0].flush(expectedResult);
 
     }));
+
+    it('should correctly handle "FulltextSearchParams"', () => {
+
+        let searchParams: FulltextSearchParams = {
+            limitToProject: 'http://rdfh.ch/projects/0001'
+        };
+
+        let httpParams = searchService['processFulltextSearchParams'](searchParams, new HttpParams());
+
+        expect(httpParams.get('limitToProject')).toEqual('http://rdfh.ch/projects/0001');
+        expect(httpParams.keys().length).toEqual(1);
+
+        searchParams = {
+            limitToResourceClass: 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing'
+        };
+
+        httpParams = searchService['processFulltextSearchParams'](searchParams, new HttpParams());
+
+        expect(httpParams.get('limitToResourceClass')).toEqual('http://0.0.0.0:3333/ontology/0001/anything/v2#Thing');
+        expect(httpParams.keys().length).toEqual(1);
+
+        searchParams = {
+            limitToStandoffClass: 'http://api.knora.org/ontology/standoff/v2#StandoffParagraphTag'
+        };
+
+        httpParams = searchService['processFulltextSearchParams'](searchParams, new HttpParams());
+
+        expect(httpParams.get('limitToStandoffClass')).toEqual('http://api.knora.org/ontology/standoff/v2#StandoffParagraphTag');
+        expect(httpParams.keys().length).toEqual(1);
+
+    });
 
     it('should perform an extended search', async(() => {
 

--- a/projects/knora/core/src/lib/services/v2/search.service.spec.ts
+++ b/projects/knora/core/src/lib/services/v2/search.service.spec.ts
@@ -136,6 +136,39 @@ describe('SearchService', () => {
 
     }));
 
+    it('should search for "testdin?" (wildcard) and return a ReadResourceSequence', async(() => {
+
+        const expectedResources = require('../../test-data/resources/Testthing.json');
+
+        searchService.doFullTextSearchReadResourceSequence('testdin?').subscribe(
+            (res) => {
+                expect(res.numberOfResources).toEqual(1);
+                expect(res.resources[0].id).toEqual('http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw');
+                expect(res.resources[0].type).toEqual('http://0.0.0.0:3333/ontology/0001/anything/v2#Thing');
+
+                expect(Object.keys(res.resources[0].properties).length).toEqual(12);
+
+                const propertiesThing: Properties = require('../../test-data/ontologyinformation/thing-properties.json');
+                expect(res.ontologyInformation.getProperties()).toEqual(propertiesThing);
+
+                const resourceClassesThing: ResourceClasses = require('../../test-data/ontologyinformation/thing-resource-classes.json');
+                expect(res.ontologyInformation.getResourceClasses()).toEqual(resourceClassesThing);
+
+                expect(spyOntoCache.getResourceClassDefinitions.calls.count()).toBe(1);
+                expect(spyOntoCache.getResourceClassDefinitions.calls.mostRecent().args).toEqual([['http://0.0.0.0:3333/ontology/0001/anything/v2#Thing']]);
+
+            }
+        );
+
+        // ? has to be URL encoded
+        const httpRequest = httpTestingController.expectOne('http://0.0.0.0:3333/v2/search/testdin%3F?offset=0');
+
+        expect(httpRequest.request.method).toEqual('GET');
+
+        httpRequest.flush(expectedResources);
+
+    }));
+
     it('should search for "testding" restricted to a project and return a ReadResourceSequence', async(() => {
 
         const expectedResources = require('../../test-data/resources/Testthing.json');

--- a/projects/knora/core/src/lib/services/v2/search.service.spec.ts
+++ b/projects/knora/core/src/lib/services/v2/search.service.spec.ts
@@ -65,6 +65,31 @@ describe('SearchService', () => {
 
     }));
 
+    it('should perform a fulltext search for the term "testding" and restrict it to a project', async(() => {
+
+        const expectedResources = require('../../test-data/resources/Testthing.json');
+
+        searchService.doFulltextSearch('testding', 0, 'http://rdfh.ch/projects/0001').subscribe(
+            (res) => {
+                expect(res.body).toEqual(expectedResources);
+            }
+        );
+
+        // see https://www.ng-conf.org/2019/angulars-httpclient-testing-depth/
+        const httpRequest = httpTestingController.match((request) => {
+            return request.url === 'http://0.0.0.0:3333/v2/search/testding' &&
+                request.params.get('offset') === '0' &&
+                request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001';
+        });
+
+        expect(httpRequest.length).toEqual(1);
+
+        expect(httpRequest[0].request.method).toEqual('GET');
+
+        httpRequest[0].flush(expectedResources);
+
+    }));
+
     it('should perform a fulltext search for the term "testding" with offset 1', async(() => {
 
         const expectedResources = require('../../test-data/resources/Testthing.json');
@@ -111,6 +136,45 @@ describe('SearchService', () => {
 
     }));
 
+    it('should search for "testding" restricted to a project and return a ReadResourceSequence', async(() => {
+
+        const expectedResources = require('../../test-data/resources/Testthing.json');
+
+        searchService.doFullTextSearchReadResourceSequence('testding', 0, 'http://rdfh.ch/projects/0001').subscribe(
+            (res) => {
+                expect(res.numberOfResources).toEqual(1);
+                expect(res.resources[0].id).toEqual('http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw');
+                expect(res.resources[0].type).toEqual('http://0.0.0.0:3333/ontology/0001/anything/v2#Thing');
+
+                expect(Object.keys(res.resources[0].properties).length).toEqual(12);
+
+                const propertiesThing: Properties = require('../../test-data/ontologyinformation/thing-properties.json');
+                expect(res.ontologyInformation.getProperties()).toEqual(propertiesThing);
+
+                const resourceClassesThing: ResourceClasses = require('../../test-data/ontologyinformation/thing-resource-classes.json');
+                expect(res.ontologyInformation.getResourceClasses()).toEqual(resourceClassesThing);
+
+                expect(spyOntoCache.getResourceClassDefinitions.calls.count()).toBe(1);
+                expect(spyOntoCache.getResourceClassDefinitions.calls.mostRecent().args).toEqual([['http://0.0.0.0:3333/ontology/0001/anything/v2#Thing']]);
+
+            }
+        );
+
+        // see https://www.ng-conf.org/2019/angulars-httpclient-testing-depth/
+        const httpRequest = httpTestingController.match((request) => {
+            return request.url === 'http://0.0.0.0:3333/v2/search/testding' &&
+                request.params.get('offset') === '0' &&
+                request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001';
+        });
+
+        expect(httpRequest.length).toEqual(1);
+
+        expect(httpRequest[0].request.method).toEqual('GET');
+
+        httpRequest[0].flush(expectedResources);
+
+    }));
+
     it('should perform a fulltext search for "testding" with offset 1 and return a ReadResourceSequence', async(() => {
 
         const expectedResources = require('../../test-data/resources/Testthing.json');
@@ -143,6 +207,30 @@ describe('SearchService', () => {
 
     }));
 
+    it('should perform a count query for a fulltext search and restrict it to a project', async(() => {
+
+        const expectedResult = require('../../test-data/resources/countQueryResult.json');
+
+        searchService.doFulltextSearchCountQuery('testding', 'http://rdfh.ch/projects/0001').subscribe(
+            (res) => {
+                expect(res.body).toEqual(expectedResult);
+            }
+        );
+
+        // see https://www.ng-conf.org/2019/angulars-httpclient-testing-depth/
+        const httpRequest = httpTestingController.match((request) => {
+            return request.url === 'http://0.0.0.0:3333/v2/search/count/testding' &&
+                request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001';
+        });
+
+        expect(httpRequest.length).toEqual(1);
+
+        expect(httpRequest[0].request.method).toEqual('GET');
+
+        httpRequest[0].flush(expectedResult);
+
+    }));
+
     it('should perform a count query for a fulltext search and return a count query result', async(() => {
 
         const expectedResult = require('../../test-data/resources/countQueryResult.json');
@@ -161,6 +249,33 @@ describe('SearchService', () => {
         expect(httpRequest.request.method).toEqual('GET');
 
         httpRequest.flush(expectedResult);
+
+    }));
+
+    it('should perform a count query for a fulltext search restricted to a project and return a count query result', async(() => {
+
+        const expectedResult = require('../../test-data/resources/countQueryResult.json');
+
+        searchService.doFullTextSearchCountQueryCountQueryResult('testding', 'http://rdfh.ch/projects/0001').subscribe(
+            (res) => {
+
+                const expectedCountQueryRes = new CountQueryResult(197);
+
+                expect(res).toEqual(expectedCountQueryRes);
+            }
+        );
+
+        // see https://www.ng-conf.org/2019/angulars-httpclient-testing-depth/
+        const httpRequest = httpTestingController.match((request) => {
+            return request.url === 'http://0.0.0.0:3333/v2/search/count/testding' &&
+                request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001';
+        });
+
+        expect(httpRequest.length).toEqual(1);
+
+        expect(httpRequest[0].request.method).toEqual('GET');
+
+        httpRequest[0].flush(expectedResult);
 
     }));
 

--- a/projects/knora/core/src/lib/services/v2/search.service.spec.ts
+++ b/projects/knora/core/src/lib/services/v2/search.service.spec.ts
@@ -20,12 +20,12 @@ describe('SearchService', () => {
         TestBed.configureTestingModule({
             imports: [
                 HttpClientTestingModule,
-                KuiCoreModule.forRoot({name: '', api: 'http://0.0.0.0:3333', app: '', media: ''})
+                KuiCoreModule.forRoot({ name: '', api: 'http://0.0.0.0:3333', app: '', media: '' })
             ],
             providers: [
                 ApiService,
                 SearchService,
-                {provide: OntologyCacheService, useValue: spyOntoCache}
+                { provide: OntologyCacheService, useValue: spyOntoCache }
             ]
         });
 
@@ -69,7 +69,7 @@ describe('SearchService', () => {
 
         const expectedResources = require('../../test-data/resources/Testthing.json');
 
-        searchService.doFulltextSearch('testding', 0, 'http://rdfh.ch/projects/0001').subscribe(
+        searchService.doFulltextSearch('testding', 0, { limitToProject: 'http://rdfh.ch/projects/0001' }).subscribe(
             (res) => {
                 expect(res.body).toEqual(expectedResources);
             }
@@ -79,7 +79,9 @@ describe('SearchService', () => {
         const httpRequest = httpTestingController.match((request) => {
             return request.url === 'http://0.0.0.0:3333/v2/search/testding' &&
                 request.params.get('offset') === '0' &&
-                request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001';
+                request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001' &&
+                request.params.keys().length === 2;
+
         });
 
         expect(httpRequest.length).toEqual(1);
@@ -173,7 +175,7 @@ describe('SearchService', () => {
 
         const expectedResources = require('../../test-data/resources/Testthing.json');
 
-        searchService.doFullTextSearchReadResourceSequence('testding', 0, 'http://rdfh.ch/projects/0001').subscribe(
+        searchService.doFullTextSearchReadResourceSequence('testding', 0, { limitToProject: 'http://rdfh.ch/projects/0001' }).subscribe(
             (res) => {
                 expect(res.numberOfResources).toEqual(1);
                 expect(res.resources[0].id).toEqual('http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw');
@@ -197,7 +199,8 @@ describe('SearchService', () => {
         const httpRequest = httpTestingController.match((request) => {
             return request.url === 'http://0.0.0.0:3333/v2/search/testding' &&
                 request.params.get('offset') === '0' &&
-                request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001';
+                request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001' &&
+                request.params.keys().length === 2;
         });
 
         expect(httpRequest.length).toEqual(1);
@@ -244,7 +247,7 @@ describe('SearchService', () => {
 
         const expectedResult = require('../../test-data/resources/countQueryResult.json');
 
-        searchService.doFulltextSearchCountQuery('testding', 'http://rdfh.ch/projects/0001').subscribe(
+        searchService.doFulltextSearchCountQuery('testding', { limitToProject: 'http://rdfh.ch/projects/0001' }).subscribe(
             (res) => {
                 expect(res.body).toEqual(expectedResult);
             }
@@ -253,7 +256,8 @@ describe('SearchService', () => {
         // see https://www.ng-conf.org/2019/angulars-httpclient-testing-depth/
         const httpRequest = httpTestingController.match((request) => {
             return request.url === 'http://0.0.0.0:3333/v2/search/count/testding' &&
-                request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001';
+                request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001' &&
+                request.params.keys().length === 1;
         });
 
         expect(httpRequest.length).toEqual(1);
@@ -289,7 +293,7 @@ describe('SearchService', () => {
 
         const expectedResult = require('../../test-data/resources/countQueryResult.json');
 
-        searchService.doFullTextSearchCountQueryCountQueryResult('testding', 'http://rdfh.ch/projects/0001').subscribe(
+        searchService.doFullTextSearchCountQueryCountQueryResult('testding', { limitToProject: 'http://rdfh.ch/projects/0001' }).subscribe(
             (res) => {
 
                 const expectedCountQueryRes = new CountQueryResult(197);
@@ -301,7 +305,8 @@ describe('SearchService', () => {
         // see https://www.ng-conf.org/2019/angulars-httpclient-testing-depth/
         const httpRequest = httpTestingController.match((request) => {
             return request.url === 'http://0.0.0.0:3333/v2/search/count/testding' &&
-                request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001';
+                request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001' &&
+                request.params.keys().length === 1;
         });
 
         expect(httpRequest.length).toEqual(1);

--- a/projects/knora/core/src/lib/services/v2/search.service.spec.ts
+++ b/projects/knora/core/src/lib/services/v2/search.service.spec.ts
@@ -477,7 +477,7 @@ OFFSET 0`;
             }
         );
 
-        const httpRequest = httpTestingController.expectOne('http://0.0.0.0:3333/v2/searchbylabel/testding');
+        const httpRequest = httpTestingController.expectOne('http://0.0.0.0:3333/v2/searchbylabel/testding?offset=0');
 
         expect(httpRequest.request.method).toEqual('GET');
 
@@ -489,7 +489,7 @@ OFFSET 0`;
 
         const expectedResource = require('../../test-data/resources/Testthing.json');
 
-        searchService.searchByLabel('testding', 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing').subscribe(
+        searchService.searchByLabel('testding', 0, { limitToResourceClass: 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing' }).subscribe(
             (res) => {
 
                 expect(res.body).toEqual(expectedResource);
@@ -498,7 +498,10 @@ OFFSET 0`;
 
         // see https://www.ng-conf.org/2019/angulars-httpclient-testing-depth/
         const httpRequest = httpTestingController.match((request) => {
-            return request.urlWithParams === 'http://0.0.0.0:3333/v2/searchbylabel/testding?limitToResourceClass=http://0.0.0.0:3333/ontology/0001/anything/v2%23Thing';
+            return request.url === 'http://0.0.0.0:3333/v2/searchbylabel/testding' &&
+                request.params.get('offset') === '0' &&
+                request.params.get('limitToResourceClass') === 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing' &&
+                request.params.keys().length === 2;
         });
 
         expect(httpRequest.length).toEqual(1);
@@ -511,7 +514,7 @@ OFFSET 0`;
 
         const expectedResource = require('../../test-data/resources/Testthing.json');
 
-        searchService.searchByLabel('testding', undefined, 'http://rdfh.ch/projects/0001').subscribe(
+        searchService.searchByLabel('testding', 0, { limitToProject: 'http://rdfh.ch/projects/0001' }).subscribe(
             (res) => {
 
                 expect(res.body).toEqual(expectedResource);
@@ -520,7 +523,10 @@ OFFSET 0`;
 
         // see https://www.ng-conf.org/2019/angulars-httpclient-testing-depth/
         const httpRequest = httpTestingController.match((request) => {
-            return request.urlWithParams === 'http://0.0.0.0:3333/v2/searchbylabel/testding?limitToProject=http://rdfh.ch/projects/0001';
+            return request.url === 'http://0.0.0.0:3333/v2/searchbylabel/testding' &&
+                request.params.get('offset') === '0' &&
+                request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001' &&
+                request.params.keys().length === 2;
         });
 
         expect(httpRequest.length).toEqual(1);
@@ -533,7 +539,7 @@ OFFSET 0`;
 
         const expectedResource = require('../../test-data/resources/Testthing.json');
 
-        searchService.searchByLabel('testding', 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing', 'http://rdfh.ch/projects/0001').subscribe(
+        searchService.searchByLabel('testding', 0, { limitToResourceClass: 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing', limitToProject: 'http://rdfh.ch/projects/0001' }).subscribe(
             (res) => {
 
                 expect(res.body).toEqual(expectedResource);
@@ -544,8 +550,10 @@ OFFSET 0`;
         const httpRequest = httpTestingController.match((request) => {
 
             return request.url === 'http://0.0.0.0:3333/v2/searchbylabel/testding'
+                && request.params.get('offset') === '0'
                 && request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001'
-                && request.params.get('limitToResourceClass') === 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing';
+                && request.params.get('limitToResourceClass') === 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing'
+                && request.params.keys().length === 3;
         });
 
         expect(httpRequest.length).toEqual(1);
@@ -579,7 +587,7 @@ OFFSET 0`;
             }
         );
 
-        const httpRequest = httpTestingController.expectOne('http://0.0.0.0:3333/v2/searchbylabel/testding');
+        const httpRequest = httpTestingController.expectOne('http://0.0.0.0:3333/v2/searchbylabel/testding?offset=0');
 
         expect(httpRequest.request.method).toEqual('GET');
 
@@ -590,7 +598,7 @@ OFFSET 0`;
 
         const expectedResource = require('../../test-data/resources/Testthing.json');
 
-        searchService.searchByLabelReadResourceSequence('testding', 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing').subscribe(
+        searchService.searchByLabelReadResourceSequence('testding', 0, { limitToResourceClass: 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing' }).subscribe(
             (res) => {
 
                 expect(res.numberOfResources).toEqual(1);
@@ -615,7 +623,9 @@ OFFSET 0`;
         const httpRequest = httpTestingController.match((request) => {
 
             return request.url === 'http://0.0.0.0:3333/v2/searchbylabel/testding'
-                && request.params.get('limitToResourceClass') === 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing';
+                && request.params.get('offset') === '0'
+                && request.params.get('limitToResourceClass') === 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing'
+                && request.params.keys().length === 2;
         });
 
         expect(httpRequest.length).toEqual(1);
@@ -627,7 +637,7 @@ OFFSET 0`;
 
         const expectedResource = require('../../test-data/resources/Testthing.json');
 
-        searchService.searchByLabelReadResourceSequence('testding', undefined, 'http://rdfh.ch/projects/0001').subscribe(
+        searchService.searchByLabelReadResourceSequence('testding', 0, { limitToProject: 'http://rdfh.ch/projects/0001' }).subscribe(
             (res) => {
 
                 expect(res.numberOfResources).toEqual(1);
@@ -652,7 +662,9 @@ OFFSET 0`;
         const httpRequest = httpTestingController.match((request) => {
 
             return request.url === 'http://0.0.0.0:3333/v2/searchbylabel/testding'
-                && request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001';
+                && request.params.get('offset') === '0'
+                && request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001'
+                && request.params.keys().length === 2;
         });
 
         expect(httpRequest.length).toEqual(1);
@@ -664,7 +676,7 @@ OFFSET 0`;
 
         const expectedResource = require('../../test-data/resources/Testthing.json');
 
-        searchService.searchByLabelReadResourceSequence('testding', 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing', 'http://rdfh.ch/projects/0001').subscribe(
+        searchService.searchByLabelReadResourceSequence('testding', 0, { limitToResourceClass: 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing', limitToProject: 'http://rdfh.ch/projects/0001' }).subscribe(
             (res) => {
 
                 expect(res.numberOfResources).toEqual(1);
@@ -689,8 +701,10 @@ OFFSET 0`;
         const httpRequest = httpTestingController.match((request) => {
 
             return request.url === 'http://0.0.0.0:3333/v2/searchbylabel/testding'
+                && request.params.get('offset') === '0'
                 && request.params.get('limitToProject') === 'http://rdfh.ch/projects/0001'
-                && request.params.get('limitToResourceClass') === 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing';
+                && request.params.get('limitToResourceClass') === 'http://0.0.0.0:3333/ontology/0001/anything/v2#Thing'
+                && request.params.keys().length === 3;
         });
 
         expect(httpRequest.length).toEqual(1);

--- a/projects/knora/core/src/lib/services/v2/search.service.ts
+++ b/projects/knora/core/src/lib/services/v2/search.service.ts
@@ -40,6 +40,7 @@ export class SearchService extends ApiService {
 
     /**
      * Assign fulltext params to http params if not undefined
+     * 
      * @param {FulltextSearchParams} params 
      * @param {HttpParams} httpParams 
      * @returns {HttpParams}
@@ -62,7 +63,8 @@ export class SearchService extends ApiService {
 
     }
     /**
-     * Assign fulltext params to http params if not undefined
+     * Assign search by label params to http params if not undefined
+     * 
      * @param {SearchByLabelParams} params 
      * @param {HttpParams} httpParams 
      * @returns {HttpParams}

--- a/projects/knora/core/src/lib/services/v2/search.service.ts
+++ b/projects/knora/core/src/lib/services/v2/search.service.ts
@@ -71,7 +71,7 @@ export class SearchService extends ApiService {
             httpParams = httpParams.set('limitToProject', projectIri);
         }
 
-        return this.httpGet('/v2/search/' + searchTerm, httpParams);
+        return this.httpGet('/v2/search/' + encodeURIComponent(searchTerm), httpParams);
     }
 
     /**
@@ -95,7 +95,7 @@ export class SearchService extends ApiService {
             httpParams = httpParams.set('limitToProject', projectIri);
         }
 
-        const res: Observable<any> = this.httpGet('/v2/search/' + searchTerm, httpParams);
+        const res: Observable<any> = this.httpGet('/v2/search/' + encodeURIComponent(searchTerm), httpParams);
 
         return res.pipe(
             mergeMap(
@@ -129,7 +129,7 @@ export class SearchService extends ApiService {
             httpParams = httpParams.set('limitToProject', projectIri);
         }
 
-        return this.httpGet('/v2/search/count/' + searchTerm, httpParams);
+        return this.httpGet('/v2/search/count/' + encodeURIComponent(searchTerm), httpParams);
     }
 
     /**
@@ -151,7 +151,7 @@ export class SearchService extends ApiService {
             httpParams = httpParams.set('limitToProject', projectIri);
         }
 
-        const res = this.httpGet('/v2/search/count/' + searchTerm, httpParams);
+        const res = this.httpGet('/v2/search/count/' + encodeURIComponent(searchTerm), httpParams);
 
         return res.pipe(
             mergeMap(
@@ -273,7 +273,7 @@ export class SearchService extends ApiService {
         }
 
         // httpGet() expects only one argument, not 2
-        return this.httpGet('/v2/searchbylabel/' + searchTerm, httpParams);
+        return this.httpGet('/v2/searchbylabel/' + encodeURIComponent(searchTerm), httpParams);
 
     }
 
@@ -301,7 +301,7 @@ export class SearchService extends ApiService {
             httpParams = httpParams.set('limitToProject', projectIri);
         }
 
-        const res = this.httpGet('/v2/searchbylabel/' + searchTerm, httpParams);
+        const res = this.httpGet('/v2/searchbylabel/' + encodeURIComponent(searchTerm), httpParams);
 
         return res.pipe(
             mergeMap(

--- a/projects/knora/core/src/lib/services/v2/search.service.ts
+++ b/projects/knora/core/src/lib/services/v2/search.service.ts
@@ -39,47 +39,57 @@ export class SearchService extends ApiService {
     }
 
     /**
-     * Assign fulltext params to http params if not undefined
-     * 
-     * @param {FulltextSearchParams} params 
-     * @param {HttpParams} httpParams 
+     * Assign fulltext search params to http params.
+     *
+     * @param {FulltextSearchParams} params
+     * @param {HttpParams} httpParams
      * @returns {HttpParams}
      */
     private processFulltextSearchParams(params: FulltextSearchParams, httpParams: HttpParams): HttpParams {
 
+        // avoid reassignment to method param
+        let searchParams = httpParams;
+
+        // HttpParams is immutable, `set` returns a new instance
+
         if (params.limitToProject !== undefined) {
-            httpParams = httpParams.set('limitToProject', params.limitToProject);
+            searchParams = searchParams.set('limitToProject', params.limitToProject);
         }
 
         if (params.limitToResourceClass !== undefined) {
-            httpParams = httpParams.set('limitToResourceClass', params.limitToResourceClass);
+            searchParams = searchParams.set('limitToResourceClass', params.limitToResourceClass);
         }
 
         if (params.limitToStandoffClass !== undefined) {
-            httpParams = httpParams.set('limitToStandoffClass', params.limitToStandoffClass);
+            searchParams = searchParams.set('limitToStandoffClass', params.limitToStandoffClass);
         }
 
-        return httpParams;
+        return searchParams;
 
     }
     /**
-     * Assign search by label params to http params if not undefined
-     * 
-     * @param {SearchByLabelParams} params 
-     * @param {HttpParams} httpParams 
+     * Assign search by label search params to http params.
+     *
+     * @param {SearchByLabelParams} params
+     * @param {HttpParams} httpParams
      * @returns {HttpParams}
      */
     private processSearchByLabelParams(params: SearchByLabelParams, httpParams: HttpParams): HttpParams {
 
+        // avoid reassignment to method param
+        let searchParams = httpParams;
+
+        // HttpParams is immutable, `set` returns a new instance
+
         if (params.limitToResourceClass !== undefined) {
-            httpParams = httpParams.set('limitToResourceClass', params.limitToResourceClass);
+            searchParams = searchParams.set('limitToResourceClass', params.limitToResourceClass);
         }
 
         if (params.limitToProject !== undefined) {
-            httpParams = httpParams.set('limitToProject', params.limitToProject);
+            searchParams = searchParams.set('limitToProject', params.limitToProject);
         }
 
-        return httpParams;
+        return searchParams;
 
     }
 
@@ -115,7 +125,7 @@ export class SearchService extends ApiService {
      *
      * @param {string} searchTerm the term to search for.
      * @param {number} offset the offset to be used (for paging, first offset is 0).
-     * @param {string} projectIri restrict search to given project, if any.
+     * @param {FulltextSearchParams} params restrictions, if any.
      * @returns Observable<ApiServiceResult>
      */
     doFulltextSearch(searchTerm: string, offset: number = 0, params?: FulltextSearchParams): Observable<ApiServiceResult> {
@@ -140,7 +150,7 @@ export class SearchService extends ApiService {
      *
      * @param {string} searchTerm the term to search for.
      * @param {number} offset the offset to be used (for paging, first offset is 0).
-     * @param {string} projectIri restrict search to given project, if any.
+     * @param {FulltextSearchParams} params restrictions, if any.
      * @returns Observable<ApiServiceResult>
      */
     doFullTextSearchReadResourceSequence(searchTerm: string, offset: number = 0, params?: FulltextSearchParams): Observable<ReadResourcesSequence> {
@@ -175,7 +185,7 @@ export class SearchService extends ApiService {
      * TODO: mark as deprecated, use of `doFullTextSearchCountQueryCountQueryResult` recommended
      *
      * @param searchTerm the term to search for.
-     * @param {string} projectIri restrict search to given project, if any.
+     * @param {FulltextSearchParams} params restrictions, if any.
      * @returns Observable<ApiServiceResult>
      */
     doFulltextSearchCountQuery(searchTerm: string, params?: FulltextSearchParams): Observable<ApiServiceResult> {
@@ -197,7 +207,7 @@ export class SearchService extends ApiService {
      * Performs a fulltext search count query and turns the result into a `CountQueryResult`.
      *
      * @param {string} searchTerm the term to search for.
-     * @param {string} projectIri restrict search to given project, if any.
+     * @param {FulltextSearchParams} params restrictions, if any.
      * @returns Observable<CountQueryResult>
      */
     doFullTextSearchCountQueryCountQueryResult(searchTerm: string, params?: FulltextSearchParams): Observable<CountQueryResult> {
@@ -313,8 +323,8 @@ export class SearchService extends ApiService {
      * TODO: mark as deprecated, use of `searchByLabelReadResourceSequence` recommended
      *
      * @param {string} searchTerm the term to search for.
-     * @param {string} [resourceClassIRI] restrict search to given resource class.
-     * @param {string} [projectIri] restrict search to given project.
+     * @param {number} offset offset to use.
+     * @param {FulltextSearchParams} params restrictions, if any.
      * @returns Observable<ApiServiceResult>
      */
     searchByLabel(searchTerm: string, offset: number = 0, params?: SearchByLabelParams): Observable<ApiServiceResult> {
@@ -340,8 +350,8 @@ export class SearchService extends ApiService {
      * Perform a search by a resource's rdfs:label and turns the results in a `ReadResourceSequence`.
      *
      * @param {string} searchTerm the term to search for.
-     * @param {string} [resourceClassIRI] restrict search to given resource class.
-     * @param {string} [projectIri] restrict search to given project.
+     * @param {number} offset offset to use.
+     * @param {FulltextSearchParams} params restrictions, if any.
      * @returns Observable<ApiServiceResult>
      */
     searchByLabelReadResourceSequence(searchTerm: string, offset: number = 0, params?: SearchByLabelParams): Observable<ReadResourcesSequence> {

--- a/projects/knora/core/src/lib/services/v2/search.service.ts
+++ b/projects/knora/core/src/lib/services/v2/search.service.ts
@@ -54,9 +54,10 @@ export class SearchService extends ApiService {
      *
      * @param {string} searchTerm the term to search for.
      * @param {number} offset the offset to be used (for paging, first offset is 0).
+     * @param {string} projectIri restrict search to given project, if any.
      * @returns Observable<ApiServiceResult>
      */
-    doFulltextSearch(searchTerm: string, offset: number = 0): Observable<ApiServiceResult> {
+    doFulltextSearch(searchTerm: string, offset: number = 0, projectIri?: string): Observable<ApiServiceResult> {
 
         if (searchTerm === undefined || searchTerm.length === 0) {
             return Observable.create(observer => observer.error('No search term given for call of SearchService.doFulltextSearch'));
@@ -65,6 +66,10 @@ export class SearchService extends ApiService {
         let httpParams = new HttpParams();
 
         httpParams = httpParams.set('offset', offset.toString());
+
+        if (projectIri !== undefined) {
+            httpParams = httpParams.set('limitToProject', projectIri);
+        }
 
         return this.httpGet('/v2/search/' + searchTerm, httpParams);
     }
@@ -74,9 +79,10 @@ export class SearchService extends ApiService {
      *
      * @param {string} searchTerm the term to search for.
      * @param {number} offset the offset to be used (for paging, first offset is 0).
+     * @param {string} projectIri restrict search to given project, if any.
      * @returns Observable<ApiServiceResult>
      */
-    doFullTextSearchReadResourceSequence(searchTerm: string, offset: number = 0): Observable<ReadResourcesSequence> {
+    doFullTextSearchReadResourceSequence(searchTerm: string, offset: number = 0, projectIri?: string): Observable<ReadResourcesSequence> {
         if (searchTerm === undefined || searchTerm.length === 0) {
             return Observable.create(observer => observer.error('No search term given for call of SearchService.doFulltextSearch'));
         }
@@ -84,6 +90,10 @@ export class SearchService extends ApiService {
         let httpParams = new HttpParams();
 
         httpParams = httpParams.set('offset', offset.toString());
+
+        if (projectIri !== undefined) {
+            httpParams = httpParams.set('limitToProject', projectIri);
+        }
 
         const res: Observable<any> = this.httpGet('/v2/search/' + searchTerm, httpParams);
 
@@ -104,30 +114,44 @@ export class SearchService extends ApiService {
      * TODO: mark as deprecated, use of `doFullTextSearchCountQueryCountQueryResult` recommended
      *
      * @param searchTerm the term to search for.
+     * @param {string} projectIri restrict search to given project, if any.
      * @returns Observable<ApiServiceResult>
      */
-    doFulltextSearchCountQuery(searchTerm: string): Observable<ApiServiceResult> {
+    doFulltextSearchCountQuery(searchTerm: string, projectIri?: string): Observable<ApiServiceResult> {
 
         if (searchTerm === undefined || searchTerm.length === 0) {
             return Observable.create(observer => observer.error('No search term given for call of SearchService.doFulltextSearchCountQuery'));
         }
 
-        return this.httpGet('/v2/search/count/' + searchTerm);
+        let httpParams = new HttpParams();
+
+        if (projectIri !== undefined) {
+            httpParams = httpParams.set('limitToProject', projectIri);
+        }
+
+        return this.httpGet('/v2/search/count/' + searchTerm, httpParams);
     }
 
     /**
      * Performs a fulltext search count query and turns the result into a `CountQueryResult`.
      *
      * @param {string} searchTerm the term to search for.
+     * @param {string} projectIri restrict search to given project, if any.
      * @returns Observable<CountQueryResult>
      */
-    doFullTextSearchCountQueryCountQueryResult(searchTerm: string): Observable<CountQueryResult> {
+    doFullTextSearchCountQueryCountQueryResult(searchTerm: string, projectIri?: string): Observable<CountQueryResult> {
 
         if (searchTerm === undefined || searchTerm.length === 0) {
             return Observable.create(observer => observer.error('No search term given for call of SearchService.doFulltextSearchCountQuery'));
         }
 
-        const res = this.httpGet('/v2/search/count/' + searchTerm);
+        let httpParams = new HttpParams();
+
+        if (projectIri !== undefined) {
+            httpParams = httpParams.set('limitToProject', projectIri);
+        }
+
+        const res = this.httpGet('/v2/search/count/' + searchTerm, httpParams);
 
         return res.pipe(
             mergeMap(
@@ -249,7 +273,7 @@ export class SearchService extends ApiService {
         }
 
         // httpGet() expects only one argument, not 2
-        return this.httpGet('/v2/searchbylabel/' + encodeURIComponent(searchTerm), httpParams);
+        return this.httpGet('/v2/searchbylabel/' + searchTerm, httpParams);
 
     }
 
@@ -277,7 +301,7 @@ export class SearchService extends ApiService {
             httpParams = httpParams.set('limitToProject', projectIri);
         }
 
-        const res = this.httpGet('/v2/searchbylabel/' + encodeURIComponent(searchTerm), httpParams);
+        const res = this.httpGet('/v2/searchbylabel/' + searchTerm, httpParams);
 
         return res.pipe(
             mergeMap(

--- a/projects/knora/core/src/lib/services/v2/search.service.ts
+++ b/projects/knora/core/src/lib/services/v2/search.service.ts
@@ -8,6 +8,24 @@ import { ApiService } from '../api.service';
 import { ConvertJSONLD } from './convert-jsonld';
 import { OntologyCacheService, OntologyInformation } from './ontology-cache.service';
 
+export interface FulltextSearchParams {
+
+    limitToResourceClass?: string;
+
+    limitToProject?: string;
+
+    limitToStandoffClass?: string;
+}
+
+export interface SearchByLabelParams {
+
+    limitToResourceClass?: string;
+
+    limitToProject?: string;
+
+    offset?: number;
+}
+
 /**
  * Performs searches (fulltext or extended) and search count queries into Knora.
  */
@@ -17,9 +35,33 @@ import { OntologyCacheService, OntologyInformation } from './ontology-cache.serv
 export class SearchService extends ApiService {
 
     constructor(public http: HttpClient,
-                @Inject(KuiCoreConfigToken) public config,
-                private _ontologyCacheService: OntologyCacheService) {
+        @Inject(KuiCoreConfigToken) public config,
+        private _ontologyCacheService: OntologyCacheService) {
         super(http, config);
+    }
+
+    /**
+     * Assign fulltext params to http params if not undefined
+     * @param {FulltextSearchParams} params 
+     * @param {HttpParams} httpParams 
+     * @returns {HttpParams}
+     */
+    private processFulltextSearchParams(params: FulltextSearchParams, httpParams: HttpParams): HttpParams {
+
+        if (params.limitToProject !== undefined) {
+            httpParams = httpParams.set('limitToProject', params.limitToProject);
+        }
+
+        if (params.limitToResourceClass !== undefined) {
+            httpParams = httpParams.set('limitToResourceClass', params.limitToResourceClass);
+        }
+
+        if (params.limitToStandoffClass !== undefined) {
+            httpParams = httpParams.set('limitToStandoffClass', params.limitToStandoffClass);
+        }
+
+        return httpParams;
+
     }
 
     /**
@@ -57,7 +99,7 @@ export class SearchService extends ApiService {
      * @param {string} projectIri restrict search to given project, if any.
      * @returns Observable<ApiServiceResult>
      */
-    doFulltextSearch(searchTerm: string, offset: number = 0, projectIri?: string): Observable<ApiServiceResult> {
+    doFulltextSearch(searchTerm: string, offset: number = 0, params?: FulltextSearchParams): Observable<ApiServiceResult> {
 
         if (searchTerm === undefined || searchTerm.length === 0) {
             return Observable.create(observer => observer.error('No search term given for call of SearchService.doFulltextSearch'));
@@ -67,8 +109,8 @@ export class SearchService extends ApiService {
 
         httpParams = httpParams.set('offset', offset.toString());
 
-        if (projectIri !== undefined) {
-            httpParams = httpParams.set('limitToProject', projectIri);
+        if (params !== undefined) {
+            httpParams = this.processFulltextSearchParams(params, httpParams);
         }
 
         return this.httpGet('/v2/search/' + encodeURIComponent(searchTerm), httpParams);
@@ -82,7 +124,7 @@ export class SearchService extends ApiService {
      * @param {string} projectIri restrict search to given project, if any.
      * @returns Observable<ApiServiceResult>
      */
-    doFullTextSearchReadResourceSequence(searchTerm: string, offset: number = 0, projectIri?: string): Observable<ReadResourcesSequence> {
+    doFullTextSearchReadResourceSequence(searchTerm: string, offset: number = 0, params?: FulltextSearchParams): Observable<ReadResourcesSequence> {
         if (searchTerm === undefined || searchTerm.length === 0) {
             return Observable.create(observer => observer.error('No search term given for call of SearchService.doFulltextSearch'));
         }
@@ -91,8 +133,8 @@ export class SearchService extends ApiService {
 
         httpParams = httpParams.set('offset', offset.toString());
 
-        if (projectIri !== undefined) {
-            httpParams = httpParams.set('limitToProject', projectIri);
+        if (params !== undefined) {
+            httpParams = this.processFulltextSearchParams(params, httpParams);
         }
 
         const res: Observable<any> = this.httpGet('/v2/search/' + encodeURIComponent(searchTerm), httpParams);
@@ -117,7 +159,7 @@ export class SearchService extends ApiService {
      * @param {string} projectIri restrict search to given project, if any.
      * @returns Observable<ApiServiceResult>
      */
-    doFulltextSearchCountQuery(searchTerm: string, projectIri?: string): Observable<ApiServiceResult> {
+    doFulltextSearchCountQuery(searchTerm: string, params?: FulltextSearchParams): Observable<ApiServiceResult> {
 
         if (searchTerm === undefined || searchTerm.length === 0) {
             return Observable.create(observer => observer.error('No search term given for call of SearchService.doFulltextSearchCountQuery'));
@@ -125,8 +167,8 @@ export class SearchService extends ApiService {
 
         let httpParams = new HttpParams();
 
-        if (projectIri !== undefined) {
-            httpParams = httpParams.set('limitToProject', projectIri);
+        if (params !== undefined) {
+            httpParams = this.processFulltextSearchParams(params, httpParams);
         }
 
         return this.httpGet('/v2/search/count/' + encodeURIComponent(searchTerm), httpParams);
@@ -139,7 +181,7 @@ export class SearchService extends ApiService {
      * @param {string} projectIri restrict search to given project, if any.
      * @returns Observable<CountQueryResult>
      */
-    doFullTextSearchCountQueryCountQueryResult(searchTerm: string, projectIri?: string): Observable<CountQueryResult> {
+    doFullTextSearchCountQueryCountQueryResult(searchTerm: string, params?: FulltextSearchParams): Observable<CountQueryResult> {
 
         if (searchTerm === undefined || searchTerm.length === 0) {
             return Observable.create(observer => observer.error('No search term given for call of SearchService.doFulltextSearchCountQuery'));
@@ -147,8 +189,8 @@ export class SearchService extends ApiService {
 
         let httpParams = new HttpParams();
 
-        if (projectIri !== undefined) {
-            httpParams = httpParams.set('limitToProject', projectIri);
+        if (params !== undefined) {
+            httpParams = this.processFulltextSearchParams(params, httpParams);
         }
 
         const res = this.httpGet('/v2/search/count/' + encodeURIComponent(searchTerm), httpParams);

--- a/projects/knora/core/src/lib/services/v2/search.service.ts
+++ b/projects/knora/core/src/lib/services/v2/search.service.ts
@@ -22,8 +22,6 @@ export interface SearchByLabelParams {
     limitToResourceClass?: string;
 
     limitToProject?: string;
-
-    offset?: number;
 }
 
 /**
@@ -58,6 +56,25 @@ export class SearchService extends ApiService {
 
         if (params.limitToStandoffClass !== undefined) {
             httpParams = httpParams.set('limitToStandoffClass', params.limitToStandoffClass);
+        }
+
+        return httpParams;
+
+    }
+    /**
+     * Assign fulltext params to http params if not undefined
+     * @param {SearchByLabelParams} params 
+     * @param {HttpParams} httpParams 
+     * @returns {HttpParams}
+     */
+    private processSearchByLabelParams(params: SearchByLabelParams, httpParams: HttpParams): HttpParams {
+
+        if (params.limitToResourceClass !== undefined) {
+            httpParams = httpParams.set('limitToResourceClass', params.limitToResourceClass);
+        }
+
+        if (params.limitToProject !== undefined) {
+            httpParams = httpParams.set('limitToProject', params.limitToProject);
         }
 
         return httpParams;
@@ -298,7 +315,7 @@ export class SearchService extends ApiService {
      * @param {string} [projectIri] restrict search to given project.
      * @returns Observable<ApiServiceResult>
      */
-    searchByLabel(searchTerm: string, resourceClassIRI?: string, projectIri?: string): Observable<ApiServiceResult> {
+    searchByLabel(searchTerm: string, offset: number = 0, params?: SearchByLabelParams): Observable<ApiServiceResult> {
 
         if (searchTerm === undefined || searchTerm.length === 0) {
             return Observable.create(observer => observer.error('No search term given for call of SearchService.doFulltextSearch'));
@@ -306,12 +323,10 @@ export class SearchService extends ApiService {
 
         let httpParams: HttpParams = new HttpParams();
 
-        if (resourceClassIRI !== undefined) {
-            httpParams = httpParams.set('limitToResourceClass', resourceClassIRI);
-        }
+        httpParams = httpParams.set('offset', offset.toString());
 
-        if (projectIri !== undefined) {
-            httpParams = httpParams.set('limitToProject', projectIri);
+        if (params !== undefined) {
+            httpParams = this.processSearchByLabelParams(params, httpParams);
         }
 
         // httpGet() expects only one argument, not 2
@@ -327,7 +342,7 @@ export class SearchService extends ApiService {
      * @param {string} [projectIri] restrict search to given project.
      * @returns Observable<ApiServiceResult>
      */
-    searchByLabelReadResourceSequence(searchTerm: string, resourceClassIRI?: string, projectIri?: string): Observable<ReadResourcesSequence> {
+    searchByLabelReadResourceSequence(searchTerm: string, offset: number = 0, params?: SearchByLabelParams): Observable<ReadResourcesSequence> {
 
         if (searchTerm === undefined || searchTerm.length === 0) {
             return Observable.create(observer => observer.error('No search term given for call of SearchService.doFulltextSearch'));
@@ -335,12 +350,10 @@ export class SearchService extends ApiService {
 
         let httpParams: HttpParams = new HttpParams();
 
-        if (resourceClassIRI !== undefined) {
-            httpParams = httpParams.set('limitToResourceClass', resourceClassIRI);
-        }
+        httpParams = httpParams.set('offset', offset.toString());
 
-        if (projectIri !== undefined) {
-            httpParams = httpParams.set('limitToProject', projectIri);
+        if (params !== undefined) {
+            httpParams = this.processSearchByLabelParams(params, httpParams);
         }
 
         const res = this.httpGet('/v2/searchbylabel/' + encodeURIComponent(searchTerm), httpParams);

--- a/projects/knora/core/src/lib/test-data/resources/Testthing-expanded.json
+++ b/projects/knora/core/src/lib/test-data/resources/Testthing-expanded.json
@@ -1,0 +1,184 @@
+{
+    "@id": "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw",
+    "@type": "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing",
+    "http://0.0.0.0:3333/ontology/0001/anything/v2#hasBoolean": {
+        "@id": "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/IN4R19yYR0ygi3K2VEHpUQ",
+        "@type": "http://api.knora.org/ontology/knora-api/v2#BooleanValue",
+        "http://api.knora.org/ontology/knora-api/v2#attachedToUser": {
+            "@id": "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+        },
+        "http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean": true,
+        "http://api.knora.org/ontology/knora-api/v2#hasPermissions": "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:KnownUser|RV knora-base:UnknownUser"
+    },
+    "http://0.0.0.0:3333/ontology/0001/anything/v2#hasColor": {
+        "@id": "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/TAziKNP8QxuyhC4Qf9-b6w",
+        "@type": "http://api.knora.org/ontology/knora-api/v2#ColorValue",
+        "http://api.knora.org/ontology/knora-api/v2#attachedToUser": {
+            "@id": "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+        },
+        "http://api.knora.org/ontology/knora-api/v2#colorValueAsColor": "#ff3333",
+        "http://api.knora.org/ontology/knora-api/v2#hasPermissions": "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:KnownUser|RV knora-base:UnknownUser"
+    },
+    "http://0.0.0.0:3333/ontology/0001/anything/v2#hasDate": {
+        "@id": "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/-rG4F5FTTu2iB5mTBPVn5Q",
+        "@type": "http://api.knora.org/ontology/knora-api/v2#DateValue",
+        "http://api.knora.org/ontology/knora-api/v2#attachedToUser": {
+            "@id": "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+        },
+        "http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar": "GREGORIAN",
+        "http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay": 13,
+        "http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra": "CE",
+        "http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth": 5,
+        "http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear": 2018,
+        "http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay": 13,
+        "http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra": "CE",
+        "http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth": 5,
+        "http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear": 2018,
+        "http://api.knora.org/ontology/knora-api/v2#hasPermissions": "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:KnownUser|RV knora-base:UnknownUser",
+        "http://api.knora.org/ontology/knora-api/v2#valueAsString": "GREGORIAN:2018-05-13 CE"
+    },
+    "http://0.0.0.0:3333/ontology/0001/anything/v2#hasDecimal": {
+        "@id": "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/bXMwnrHvQH2DMjOFrGmNzg",
+        "@type": "http://api.knora.org/ontology/knora-api/v2#DecimalValue",
+        "http://api.knora.org/ontology/knora-api/v2#attachedToUser": {
+            "@id": "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+        },
+        "http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal": {
+            "@type": "http://www.w3.org/2001/XMLSchema#decimal",
+            "@value": "1.5"
+        },
+        "http://api.knora.org/ontology/knora-api/v2#hasPermissions": "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:KnownUser|RV knora-base:UnknownUser"
+    },
+    "http://0.0.0.0:3333/ontology/0001/anything/v2#hasInteger": {
+        "@id": "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/dJ1ES8QTQNepFKF5-EAqdg",
+        "@type": "http://api.knora.org/ontology/knora-api/v2#IntValue",
+        "http://api.knora.org/ontology/knora-api/v2#attachedToUser": {
+            "@id": "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+        },
+        "http://api.knora.org/ontology/knora-api/v2#hasPermissions": "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:KnownUser|RV knora-base:UnknownUser",
+        "http://api.knora.org/ontology/knora-api/v2#intValueAsInt": 1
+    },
+    "http://0.0.0.0:3333/ontology/0001/anything/v2#hasInterval": {
+        "@id": "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/RbDKPKHWTC-0lkRKae-E6A",
+        "@type": "http://api.knora.org/ontology/knora-api/v2#IntervalValue",
+        "http://api.knora.org/ontology/knora-api/v2#attachedToUser": {
+            "@id": "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+        },
+        "http://api.knora.org/ontology/knora-api/v2#hasPermissions": "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:KnownUser|RV knora-base:UnknownUser",
+        "http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd": {
+            "@type": "http://www.w3.org/2001/XMLSchema#decimal",
+            "@value": "216000"
+        },
+        "http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart": {
+            "@type": "http://www.w3.org/2001/XMLSchema#decimal",
+            "@value": "0"
+        }
+    },
+    "http://0.0.0.0:3333/ontology/0001/anything/v2#hasListItem": {
+        "@id": "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/XAhEeE3kSVqM4JPGdLt4Ew",
+        "@type": "http://api.knora.org/ontology/knora-api/v2#ListValue",
+        "http://api.knora.org/ontology/knora-api/v2#attachedToUser": {
+            "@id": "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+        },
+        "http://api.knora.org/ontology/knora-api/v2#hasPermissions": "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:KnownUser|RV knora-base:UnknownUser",
+        "http://api.knora.org/ontology/knora-api/v2#listValueAsListNode": {
+            "@id": "http://rdfh.ch/lists/0001/treeList01"
+        }
+    },
+    "http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherListItem": {
+        "@id": "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/j8VQjbD0RsyxpyuvfFJCDA",
+        "@type": "http://api.knora.org/ontology/knora-api/v2#ListValue",
+        "http://api.knora.org/ontology/knora-api/v2#attachedToUser": {
+            "@id": "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+        },
+        "http://api.knora.org/ontology/knora-api/v2#hasPermissions": "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:KnownUser|RV knora-base:UnknownUser",
+        "http://api.knora.org/ontology/knora-api/v2#listValueAsListNode": {
+            "@id": "http://rdfh.ch/lists/0001/otherTreeList01"
+        }
+    },
+    "http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue": {
+        "@id": "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/uvRVxzL1RD-t9VIQ1TpfUw",
+        "@type": "http://api.knora.org/ontology/knora-api/v2#LinkValue",
+        "http://api.knora.org/ontology/knora-api/v2#attachedToUser": {
+            "@id": "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+        },
+        "http://api.knora.org/ontology/knora-api/v2#hasPermissions": "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:KnownUser|RV knora-base:UnknownUser",
+        "http://api.knora.org/ontology/knora-api/v2#linkValueHasTarget": {
+            "@id": "http://rdfh.ch/0001/0C-0L1kORryKzJAJxxRyRQ",
+            "@type": "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing",
+            "http://api.knora.org/ontology/knora-api/v2#arkUrl": {
+                "@type": "http://www.w3.org/2001/XMLSchema#anyURI",
+                "@value": "http://0.0.0.0:3336/ark:/72163/1/0001/0C=0L1kORryKzJAJxxRyRQY"
+            },
+            "http://api.knora.org/ontology/knora-api/v2#attachedToProject": {
+                "@id": "http://rdfh.ch/projects/0001"
+            },
+            "http://api.knora.org/ontology/knora-api/v2#attachedToUser": {
+                "@id": "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+            },
+            "http://api.knora.org/ontology/knora-api/v2#creationDate": {
+                "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp",
+                "@value": "2016-10-17T17:16:04.916Z"
+            },
+            "http://api.knora.org/ontology/knora-api/v2#hasPermissions": "V knora-base:UnknownUser|M knora-base:ProjectMember",
+            "http://api.knora.org/ontology/knora-api/v2#versionArkUrl": {
+                "@type": "http://www.w3.org/2001/XMLSchema#anyURI",
+                "@value": "http://0.0.0.0:3336/ark:/72163/1/0001/0C=0L1kORryKzJAJxxRyRQY.20161017T171604916Z"
+            },
+            "http://www.w3.org/2000/01/rdf-schema#label": "Sierra"
+        }
+    },
+    "http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext": {
+        "@id": "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/rvB4eQ5MTF-Qxq0YgkwaDg",
+        "@type": "http://api.knora.org/ontology/knora-api/v2#TextValue",
+        "http://api.knora.org/ontology/knora-api/v2#attachedToUser": {
+            "@id": "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+        },
+        "http://api.knora.org/ontology/knora-api/v2#hasPermissions": "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:KnownUser|RV knora-base:UnknownUser",
+        "http://api.knora.org/ontology/knora-api/v2#textValueAsXml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<text><p>test with <strong>markup</strong></p></text>",
+        "http://api.knora.org/ontology/knora-api/v2#textValueHasMapping": {
+            "@id": "http://rdfh.ch/standoff/mappings/StandardMapping"
+        }
+    },
+    "http://0.0.0.0:3333/ontology/0001/anything/v2#hasText": {
+        "@id": "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/SZyeLLmOTcCCuS3B0VksHQ",
+        "@type": "http://api.knora.org/ontology/knora-api/v2#TextValue",
+        "http://api.knora.org/ontology/knora-api/v2#attachedToUser": {
+            "@id": "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+        },
+        "http://api.knora.org/ontology/knora-api/v2#hasPermissions": "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:KnownUser|RV knora-base:UnknownUser",
+        "http://api.knora.org/ontology/knora-api/v2#valueAsString": "test"
+    },
+    "http://0.0.0.0:3333/ontology/0001/anything/v2#hasUri": {
+        "@id": "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/uBAmWuRhR-eo1u1eP7qqNg",
+        "@type": "http://api.knora.org/ontology/knora-api/v2#UriValue",
+        "http://api.knora.org/ontology/knora-api/v2#attachedToUser": {
+            "@id": "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+        },
+        "http://api.knora.org/ontology/knora-api/v2#hasPermissions": "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:KnownUser|RV knora-base:UnknownUser",
+        "http://api.knora.org/ontology/knora-api/v2#uriValueAsUri": {
+            "@type": "http://www.w3.org/2001/XMLSchema#anyURI",
+            "@value": "http://www.google.ch"
+        }
+    },
+    "http://api.knora.org/ontology/knora-api/v2#arkUrl": {
+        "@type": "http://www.w3.org/2001/XMLSchema#anyURI",
+        "@value": "http://0.0.0.0:3336/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk"
+    },
+    "http://api.knora.org/ontology/knora-api/v2#attachedToProject": {
+        "@id": "http://rdfh.ch/projects/0001"
+    },
+    "http://api.knora.org/ontology/knora-api/v2#attachedToUser": {
+        "@id": "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+    },
+    "http://api.knora.org/ontology/knora-api/v2#creationDate": {
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp",
+        "@value": "2018-05-28T15:52:03.897Z"
+    },
+    "http://api.knora.org/ontology/knora-api/v2#hasPermissions": "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:KnownUser|RV knora-base:UnknownUser",
+    "http://api.knora.org/ontology/knora-api/v2#versionArkUrl": {
+        "@type": "http://www.w3.org/2001/XMLSchema#anyURI",
+        "@value": "http://0.0.0.0:3336/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk.20180528T155203897Z"
+    },
+    "http://www.w3.org/2000/01/rdf-schema#label": "testding"
+}

--- a/projects/knora/search/src/lib/extended-search/select-property/specify-property-value/link-value/link-value.component.spec.ts
+++ b/projects/knora/search/src/lib/extended-search/select-property/specify-property-value/link-value/link-value.component.spec.ts
@@ -90,6 +90,10 @@ describe('LinkValueComponent', () => {
 
         testHostFixture.detectChanges();
 
+        expect(searchService.searchByLabelReadResourceSequence).toHaveBeenCalledTimes(1);
+
+        expect(searchService.searchByLabelReadResourceSequence).toHaveBeenCalledWith('Leonhard Euler', 0, { limitToResourceClass: 'http://0.0.0.0:3333/ontology/0801/beol/v2#person' });
+
         expect(testHostComponent.linkValue.resources.length).toEqual(25);
 
         expect(testHostComponent.linkValue.resources[0].id).toEqual('http://rdfh.ch/00505cf0a803');
@@ -99,7 +103,7 @@ describe('LinkValueComponent', () => {
 
     it('should return a selected resource', () => {
 
-        testHostComponent.linkValue.form.setValue({'resource': new ReadResource('http://rdfh.ch/0802/VKPSBh1IRw2lLhc2r6uCfQ', 'testtype', 'testlabel', [], [], [], [], {})});
+        testHostComponent.linkValue.form.setValue({ 'resource': new ReadResource('http://rdfh.ch/0802/VKPSBh1IRw2lLhc2r6uCfQ', 'testtype', 'testlabel', [], [], [], [], {}) });
 
         testHostFixture.detectChanges();
 

--- a/projects/knora/search/src/lib/extended-search/select-property/specify-property-value/link-value/link-value.component.ts
+++ b/projects/knora/search/src/lib/extended-search/select-property/specify-property-value/link-value/link-value.component.ts
@@ -74,7 +74,7 @@ export class LinkValueComponent implements OnInit, OnDestroy, PropertyValue {
         // at least 3 characters are required
         if (searchTerm.length >= 3) {
 
-            this._searchService.searchByLabelReadResourceSequence(searchTerm, this._restrictToResourceClass).subscribe(
+            this._searchService.searchByLabelReadResourceSequence(searchTerm, 0, { limitToResourceClass: this._restrictToResourceClass }).subscribe(
                 (result: ReadResourcesSequence) => {
                     this.resources = result.resources;
                 }, function (err) {

--- a/projects/knora/viewer/src/lib/view/kui-view.ts
+++ b/projects/knora/viewer/src/lib/view/kui-view.ts
@@ -24,7 +24,6 @@ export abstract class KuiView implements OnInit, OnDestroy {
     abstract searchQuery: string;
     abstract badRequest: boolean;
     abstract searchMode: string;
-    abstract projectIri: string;
     abstract numberOfAllResults: number;
     abstract KnoraConstants: KnoraConstants;
     abstract rerender: boolean;
@@ -42,7 +41,6 @@ export abstract class KuiView implements OnInit, OnDestroy {
     ngOnInit() {
         this.navigationSubscription = this._route.paramMap.subscribe((params: Params) => {
             this.searchMode = params.get('mode');
-            this.projectIri = params.get('project');
 
             // init offset  and result
             this.offset = 0;
@@ -79,7 +77,7 @@ export abstract class KuiView implements OnInit, OnDestroy {
             this._router.navigate([''], { relativeTo: this._route });
             return;
         } else {
-            this.searchQuery = <string> gravsearch;
+            this.searchQuery = <string>gravsearch;
         }
     }
 
@@ -102,31 +100,28 @@ export abstract class KuiView implements OnInit, OnDestroy {
                 this.isLoading = false;
                 this.rerender = false;
             } else {
-            if (this.projectIri !== null && this.projectIri !== undefined) {
-                this.searchQuery += '?limitToProject=' + this.projectIri;
-            }
 
-            if (this.offset === 0) {
-                // perform count query
-                this._searchService.doFullTextSearchCountQueryCountQueryResult(this.searchQuery)
-                    .subscribe(
-                        this.showNumberOfAllResults,
+                if (this.offset === 0) {
+                    // perform count query
+                    this._searchService.doFullTextSearchCountQueryCountQueryResult(this.searchQuery)
+                        .subscribe(
+                            this.showNumberOfAllResults,
                             (error: ApiServiceError) => {
-                                this.errorMessage = <ApiServiceError> error;
-                        }
-                    );
-            }
+                                this.errorMessage = <ApiServiceError>error;
+                            }
+                        );
+                }
 
-            // perform full text search
-            this._searchService.doFullTextSearchReadResourceSequence(this.searchQuery, this.offset)
-                .subscribe(
-                    this.processSearchResults, // function pointer
+                // perform full text search
+                this._searchService.doFullTextSearchReadResourceSequence(this.searchQuery, this.offset)
+                    .subscribe(
+                        this.processSearchResults, // function pointer
                         (error: ApiServiceError) => {
-                            this.errorMessage = <ApiServiceError> error;
+                            this.errorMessage = <ApiServiceError>error;
                             console.log('error', error);
                             console.log('message', this.errorMessage);
-                    }
-                );
+                        }
+                    );
             }
 
             // EXTENDED SEARCH
@@ -137,7 +132,7 @@ export abstract class KuiView implements OnInit, OnDestroy {
                     .subscribe(
                         this.showNumberOfAllResults,
                         (error: ApiServiceError) => {
-                            this.errorMessage = <ApiServiceError> error;
+                            this.errorMessage = <ApiServiceError>error;
                         }
                     );
             }
@@ -145,7 +140,7 @@ export abstract class KuiView implements OnInit, OnDestroy {
                 .subscribe(
                     this.processSearchResults, // function pointer
                     (error: ApiServiceError) => {
-                        this.errorMessage = <ApiServiceError> error;
+                        this.errorMessage = <ApiServiceError>error;
                     });
 
         } else {

--- a/projects/knora/viewer/src/lib/view/search-results/search-results.component.spec.ts
+++ b/projects/knora/viewer/src/lib/view/search-results/search-results.component.spec.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute } from '@angular/router';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { KuiCoreConfig, KuiCoreConfigToken } from '@knora/core';
+import { KuiCoreConfig, KuiCoreConfigToken, SearchService, ExtendedSearchParams, SearchParamsService, CountQueryResult, ConvertJSONLD, ResourceClasses, Properties, OntologyInformation, FulltextSearchParams } from '@knora/core';
 import { SearchResultsComponent } from './search-results.component';
 import { ListViewComponent } from '../list-view/list-view.component';
 import { GridViewComponent } from '../grid-view/grid-view.component';
@@ -12,7 +12,7 @@ import { TableViewComponent } from '../table-view/table-view.component';
 import { GraphViewComponent } from '../graph-view/graph-view.component';
 import { TextValueAsHtmlComponent } from '../../property/text-value/text-value-as-html/text-value-as-html.component';
 import { DateValueComponent } from '../../property/date-value/date-value.component';
-import { of } from 'rxjs';
+import { of, BehaviorSubject } from 'rxjs';
 import { KuiActionModule } from 'projects/knora/action/src/public_api';
 
 describe('SearchResultsComponent', () => {
@@ -22,7 +22,14 @@ describe('SearchResultsComponent', () => {
     const mode = 'extended';
     const q = 'test';
 
+    let mockSearchParamService;
+    let searchServiceSpy: jasmine.SpyObj<SearchService>; // see https://angular.io/guide/testing#angular-testbed
+
     beforeEach(async(() => {
+        mockSearchParamService = new MockSearchParamsService();
+        const spySearchService =
+            jasmine.createSpyObj('SearchService', ['doExtendedSearchCountQueryCountQueryResult', 'doExtendedSearchReadResourceSequence', 'doFullTextSearchReadResourceSequence', 'doFullTextSearchCountQueryCountQueryResult']);
+
         TestBed.configureTestingModule({
             imports: [
                 KuiActionModule,
@@ -58,13 +65,42 @@ describe('SearchResultsComponent', () => {
                         })
                     }
                 },
-                {
-                    provide: KuiCoreConfigToken,
-                    useValue: KuiCoreConfig
-                },
+                { provide: KuiCoreConfigToken, useValue: KuiCoreConfig },
+                { provide: SearchParamsService, useValue: mockSearchParamService },
+                { provide: SearchService, useValue: spySearchService },
                 HttpClient
             ]
         }).compileComponents();
+
+        searchServiceSpy = TestBed.get(SearchService);
+
+        searchServiceSpy.doExtendedSearchCountQueryCountQueryResult.and.callFake((gravsearch: string) => {
+
+            const countQueryRes = new CountQueryResult(197);
+
+            return of(
+                countQueryRes
+            );
+        });
+
+        searchServiceSpy.doExtendedSearchReadResourceSequence.and.callFake((gravsearch: string) => {
+
+            const letters = require('../../../../../core/src/lib/test-data/search/SearchResultNarr-expanded.json'); // mock response
+
+            const lettersSeq = ConvertJSONLD.createReadResourcesSequenceFromJsonLD(letters);
+
+            const resClasses: ResourceClasses = require('../../../../../core/src/lib/test-data/ontologyinformation/thing-resource-classes.json');
+            const properties: Properties = require('../../../../../core/src/lib/test-data/ontologyinformation/thing-properties.json');
+
+            const ontoInfo = new OntologyInformation({}, resClasses, properties);
+
+            lettersSeq.ontologyInformation.updateOntologyInformation(ontoInfo);
+
+            return of(
+                lettersSeq
+            );
+        });
+
     }));
 
     beforeEach(() => {
@@ -76,4 +112,38 @@ describe('SearchResultsComponent', () => {
     it('should create', () => {
         expect(component).toBeTruthy();
     });
+
+    it('should perform a count query', () => {
+        expect(searchServiceSpy.doExtendedSearchCountQueryCountQueryResult).toHaveBeenCalledTimes(1);
+
+        expect(searchServiceSpy.doExtendedSearchCountQueryCountQueryResult).toHaveBeenCalledWith('testquery0');
+
+        expect(component.numberOfAllResults).toEqual(197);
+    });
+
+    it('should perform a gravsearch query', () => {
+        expect(searchServiceSpy.doExtendedSearchReadResourceSequence).toHaveBeenCalledTimes(1);
+
+        expect(searchServiceSpy.doExtendedSearchReadResourceSequence).toHaveBeenCalledWith('testquery0');
+
+        expect(component.result.length).toEqual(25);
+    });
 });
+
+class MockSearchParamsService {
+
+    private _currentSearchParams: BehaviorSubject<any>;
+
+    constructor() {
+        this._currentSearchParams = new BehaviorSubject<ExtendedSearchParams>(new ExtendedSearchParams((offset: number) => 'testquery' + offset));
+    }
+
+    changeSearchParamsMsg(searchParams: ExtendedSearchParams): void {
+        this._currentSearchParams.next(searchParams);
+    }
+
+    getSearchParams(): ExtendedSearchParams {
+        return this._currentSearchParams.getValue();
+    }
+
+}

--- a/projects/knora/viewer/src/lib/view/search-results/search-results.component.spec.ts
+++ b/projects/knora/viewer/src/lib/view/search-results/search-results.component.spec.ts
@@ -4,7 +4,18 @@ import { ActivatedRoute } from '@angular/router';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { KuiCoreConfig, KuiCoreConfigToken, SearchService, ExtendedSearchParams, SearchParamsService, CountQueryResult, ConvertJSONLD, ResourceClasses, Properties, OntologyInformation, FulltextSearchParams } from '@knora/core';
+import {
+    KuiCoreConfig,
+    KuiCoreConfigToken,
+    SearchService,
+    ExtendedSearchParams,
+    SearchParamsService,
+    CountQueryResult,
+    ConvertJSONLD,
+    ResourceClasses,
+    Properties,
+    OntologyInformation
+} from '@knora/core';
 import { SearchResultsComponent } from './search-results.component';
 import { ListViewComponent } from '../list-view/list-view.component';
 import { GridViewComponent } from '../grid-view/grid-view.component';
@@ -19,8 +30,9 @@ describe('SearchResultsComponent', () => {
     let component: SearchResultsComponent;
     let fixture: ComponentFixture<SearchResultsComponent>;
 
-    const mode = 'extended';
-    const q = 'test';
+    let mode: string; // search mode = extended or fulltext
+    let project; // project iri
+    const q = 'test'; // query terms
 
     let mockSearchParamService;
     let searchServiceSpy: jasmine.SpyObj<SearchService>; // see https://angular.io/guide/testing#angular-testbed
@@ -28,7 +40,11 @@ describe('SearchResultsComponent', () => {
     beforeEach(async(() => {
         mockSearchParamService = new MockSearchParamsService();
         const spySearchService =
-            jasmine.createSpyObj('SearchService', ['doExtendedSearchCountQueryCountQueryResult', 'doExtendedSearchReadResourceSequence', 'doFullTextSearchReadResourceSequence', 'doFullTextSearchCountQueryCountQueryResult']);
+            jasmine.createSpyObj('SearchService',
+                ['doExtendedSearchCountQueryCountQueryResult',
+                    'doExtendedSearchReadResourceSequence',
+                    'doFullTextSearchReadResourceSequence',
+                    'doFullTextSearchCountQueryCountQueryResult']);
 
         TestBed.configureTestingModule({
             imports: [
@@ -58,7 +74,14 @@ describe('SearchResultsComponent', () => {
                             get: (param: string) => {
                                 if (param === 'q') {
                                     return q;
-                                } else {
+                                } else if (param == 'project') {
+                                    if (project !== undefined) {
+                                        return project;
+                                    } else {
+                                        return null;
+                                    }
+                                }
+                                else {
                                     return mode;
                                 }
                             }
@@ -74,59 +97,152 @@ describe('SearchResultsComponent', () => {
 
         searchServiceSpy = TestBed.get(SearchService);
 
+        // Extended search mock
+
         searchServiceSpy.doExtendedSearchCountQueryCountQueryResult.and.callFake((gravsearch: string) => {
 
-            const countQueryRes = new CountQueryResult(197);
+            const countQueryRes = new CountQueryResult(1);
 
             return of(
                 countQueryRes
             );
         });
 
-        searchServiceSpy.doExtendedSearchReadResourceSequence.and.callFake((gravsearch: string) => {
+        searchServiceSpy.doExtendedSearchReadResourceSequence.and.callFake(() => {
 
-            const letters = require('../../../../../core/src/lib/test-data/search/SearchResultNarr-expanded.json'); // mock response
+            const things = require('../../../../../core/src/lib/test-data/resources/Testthing-expanded.json'); // mock response
 
-            const lettersSeq = ConvertJSONLD.createReadResourcesSequenceFromJsonLD(letters);
+            const thingsSeq = ConvertJSONLD.createReadResourcesSequenceFromJsonLD(things);
 
             const resClasses: ResourceClasses = require('../../../../../core/src/lib/test-data/ontologyinformation/thing-resource-classes.json');
             const properties: Properties = require('../../../../../core/src/lib/test-data/ontologyinformation/thing-properties.json');
 
             const ontoInfo = new OntologyInformation({}, resClasses, properties);
 
-            lettersSeq.ontologyInformation.updateOntologyInformation(ontoInfo);
+            thingsSeq.ontologyInformation.updateOntologyInformation(ontoInfo);
 
             return of(
-                lettersSeq
+                thingsSeq
+            );
+        });
+
+        // Fulltext search mock
+
+        searchServiceSpy.doFullTextSearchCountQueryCountQueryResult.and.callFake((searchTerm: string) => {
+
+            const countQueryRes = new CountQueryResult(1);
+
+            return of(
+                countQueryRes
+            );
+        });
+
+        searchServiceSpy.doFullTextSearchReadResourceSequence.and.callFake(() => {
+
+            const things = require('../../../../../core/src/lib/test-data/resources/Testthing-expanded.json'); // mock response
+
+            const thingsSeq = ConvertJSONLD.createReadResourcesSequenceFromJsonLD(things);
+
+            const resClasses: ResourceClasses = require('../../../../../core/src/lib/test-data/ontologyinformation/thing-resource-classes.json');
+            const properties: Properties = require('../../../../../core/src/lib/test-data/ontologyinformation/thing-properties.json');
+
+            const ontoInfo = new OntologyInformation({}, resClasses, properties);
+
+            thingsSeq.ontologyInformation.updateOntologyInformation(ontoInfo);
+
+            return of(
+                thingsSeq
             );
         });
 
     }));
 
-    beforeEach(() => {
-        fixture = TestBed.createComponent(SearchResultsComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
+    describe('extended search', () => {
+        beforeEach(() => {
+            mode = 'extended';
+            fixture = TestBed.createComponent(SearchResultsComponent);
+            component = fixture.componentInstance;
+            fixture.detectChanges();
+        });
+
+        it('should create', () => {
+            expect(component).toBeTruthy();
+        });
+
+        it('should perform a count query', () => {
+            expect(searchServiceSpy.doExtendedSearchCountQueryCountQueryResult).toHaveBeenCalledTimes(1);
+
+            expect(searchServiceSpy.doExtendedSearchCountQueryCountQueryResult).toHaveBeenCalledWith('testquery0');
+
+            expect(component.numberOfAllResults).toEqual(1);
+        });
+
+        it('should perform a gravsearch query', () => {
+            expect(searchServiceSpy.doExtendedSearchReadResourceSequence).toHaveBeenCalledTimes(1);
+
+            expect(searchServiceSpy.doExtendedSearchReadResourceSequence).toHaveBeenCalledWith('testquery0');
+
+            expect(component.result.length).toEqual(1);
+        });
     });
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
+    describe('fulltext search without a project', () => {
+        beforeEach(() => {
+            mode = 'fulltext';
+            fixture = TestBed.createComponent(SearchResultsComponent);
+            component = fixture.componentInstance;
+            fixture.detectChanges();
+        });
+
+        it('should create', () => {
+            expect(component).toBeTruthy();
+        });
+
+        it('should perform a count query', () => {
+            expect(searchServiceSpy.doFullTextSearchCountQueryCountQueryResult).toHaveBeenCalledTimes(1);
+
+            expect(searchServiceSpy.doFullTextSearchCountQueryCountQueryResult).toHaveBeenCalledWith('test', undefined);
+
+            expect(component.numberOfAllResults).toEqual(1);
+        });
+
+        it('should perform a fulltext query', () => {
+            expect(searchServiceSpy.doFullTextSearchReadResourceSequence).toHaveBeenCalledTimes(1);
+
+            expect(searchServiceSpy.doFullTextSearchReadResourceSequence).toHaveBeenCalledWith('test', 0, undefined);
+
+            expect(component.result.length).toEqual(1);
+        });
     });
 
-    it('should perform a count query', () => {
-        expect(searchServiceSpy.doExtendedSearchCountQueryCountQueryResult).toHaveBeenCalledTimes(1);
+    describe('fulltext search with a project', () => {
+        beforeEach(() => {
+            mode = 'fulltext';
+            project = 'http://rdfh.ch/projects/0001';
+            fixture = TestBed.createComponent(SearchResultsComponent);
+            component = fixture.componentInstance;
+            fixture.detectChanges();
+        });
 
-        expect(searchServiceSpy.doExtendedSearchCountQueryCountQueryResult).toHaveBeenCalledWith('testquery0');
+        it('should create', () => {
+            expect(component).toBeTruthy();
+        });
 
-        expect(component.numberOfAllResults).toEqual(197);
-    });
+        it('should perform a count query', () => {
+            expect(searchServiceSpy.doFullTextSearchCountQueryCountQueryResult).toHaveBeenCalledTimes(1);
 
-    it('should perform a gravsearch query', () => {
-        expect(searchServiceSpy.doExtendedSearchReadResourceSequence).toHaveBeenCalledTimes(1);
+            expect(searchServiceSpy.doFullTextSearchCountQueryCountQueryResult).toHaveBeenCalledWith('test', { limitToProject: 'http://rdfh.ch/projects/0001' });
 
-        expect(searchServiceSpy.doExtendedSearchReadResourceSequence).toHaveBeenCalledWith('testquery0');
+            expect(component.numberOfAllResults).toEqual(1);
+        });
 
-        expect(component.result.length).toEqual(25);
+        it('should perform a fulltext query', () => {
+            expect(searchServiceSpy.doFullTextSearchReadResourceSequence).toHaveBeenCalledTimes(1);
+
+            expect(searchServiceSpy.doFullTextSearchReadResourceSequence).toHaveBeenCalledWith('test', 0, { limitToProject: 'http://rdfh.ch/projects/0001' });
+
+            expect(component.result.length).toEqual(1);
+        });
     });
 });
 

--- a/projects/knora/viewer/src/lib/view/search-results/search-results.component.ts
+++ b/projects/knora/viewer/src/lib/view/search-results/search-results.component.ts
@@ -165,12 +165,18 @@ export class SearchResultsComponent implements OnInit, OnChanges, OnDestroy {
                 this.rerender = false;
             } else {
 
+                let searchParams;
+
+                if (this.projectIri !== undefined) {
+                    searchParams = { limitToProject: this.projectIri };
+                }
+
                 if (this.offset === 0) {
                     // perform count query
                     this._searchService
                         .doFullTextSearchCountQueryCountQueryResult(
                             this.searchQuery,
-                            { limitToProject: this.projectIri }
+                            searchParams
                         )
                         .subscribe(
                             this.showNumberOfAllResults,
@@ -185,7 +191,7 @@ export class SearchResultsComponent implements OnInit, OnChanges, OnDestroy {
                     .doFullTextSearchReadResourceSequence(
                         this.searchQuery,
                         this.offset,
-                        { limitToProject: this.projectIri }
+                        searchParams
                     )
                     .subscribe(
                         this.processSearchResults, // function pointer

--- a/projects/knora/viewer/src/lib/view/search-results/search-results.component.ts
+++ b/projects/knora/viewer/src/lib/view/search-results/search-results.component.ts
@@ -164,15 +164,13 @@ export class SearchResultsComponent implements OnInit, OnChanges, OnDestroy {
                 this.loading = false;
                 this.rerender = false;
             } else {
-                if (this.projectIri) {
-                    this.searchQuery += '?limitToProject=' + this.projectIri;
-                }
 
                 if (this.offset === 0) {
                     // perform count query
                     this._searchService
                         .doFullTextSearchCountQueryCountQueryResult(
-                            this.searchQuery
+                            this.searchQuery,
+                            { limitToProject: this.projectIri }
                         )
                         .subscribe(
                             this.showNumberOfAllResults,
@@ -186,7 +184,8 @@ export class SearchResultsComponent implements OnInit, OnChanges, OnDestroy {
                 this._searchService
                     .doFullTextSearchReadResourceSequence(
                         this.searchQuery,
-                        this.offset
+                        this.offset,
+                        { limitToProject: this.projectIri }
                     )
                     .subscribe(
                         this.processSearchResults, // function pointer


### PR DESCRIPTION
This PR introduces the option to restrict a fulltext search to a project.

Required by https://github.com/dhlab-basel/beol/issues/138