### PR TITLE
fix(viewer): Reload search results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,4 @@
-# Javascript Node CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-javascript/ for more details
-#
 version: 2
-general:
-  branches:
-    ignore:
-    - gh-pages
-
 jobs:
   build:
     docker:

--- a/projects/knora/viewer/src/lib/view/search-results/search-results.component.html
+++ b/projects/knora/viewer/src/lib/view/search-results/search-results.component.html
@@ -1,6 +1,6 @@
 <kui-progress-indicator *ngIf="loading"></kui-progress-indicator>
 
-<div *ngIf="!rerender && !badRequest">
+<div *ngIf="!loading && !badRequest">
 
     <div *ngIf="numberOfAllResults !== 0 && result; else noResult">
 
@@ -55,7 +55,8 @@
         </div> -->
 
         <div class="load-panel" *ngIf="result.length > 0">
-            <button mat-flat-button color="primary" class="link center" (click)="loadMore(offset)" *ngIf="offset < maxOffset">Load more
+            <button mat-flat-button color="primary" class="link center" (click)="loadMore(offset)"
+                    *ngIf="offset < maxOffset">Load more
                 <mat-icon>keyboard_arrow_down</mat-icon>
             </button>
         </div>
@@ -64,7 +65,8 @@
 
     <!-- In case of 0 result -->
     <ng-template #noResult>
-        <kui-message [message]="{status: 404, statusMsg: 'No results', statusText: 'Sorry, but we couldn\'t find any results matching your search'}" [medium]="true"></kui-message>
+        <kui-message [message]="{status: 404, statusMsg: 'No results', statusText: 'Sorry, but we couldn\'t find any results matching your search'}"
+                     [medium]="true"></kui-message>
         <!-- <p><strong>No result</strong></p> -->
     </ng-template>
 

--- a/projects/knora/viewer/src/lib/view/search-results/search-results.component.spec.ts
+++ b/projects/knora/viewer/src/lib/view/search-results/search-results.component.spec.ts
@@ -1,30 +1,19 @@
+import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatCardModule, MatIconModule, MatListModule, MatTabsModule } from '@angular/material';
 import { ActivatedRoute } from '@angular/router';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import {
-    KuiCoreConfig,
-    KuiCoreConfigToken,
-    SearchService,
-    ExtendedSearchParams,
-    SearchParamsService,
-    CountQueryResult,
-    ConvertJSONLD,
-    ResourceClasses,
-    Properties,
-    OntologyInformation
-} from '@knora/core';
-import { SearchResultsComponent } from './search-results.component';
-import { ListViewComponent } from '../list-view/list-view.component';
-import { GridViewComponent } from '../grid-view/grid-view.component';
-import { TableViewComponent } from '../table-view/table-view.component';
-import { GraphViewComponent } from '../graph-view/graph-view.component';
-import { TextValueAsHtmlComponent } from '../../property/text-value/text-value-as-html/text-value-as-html.component';
-import { DateValueComponent } from '../../property/date-value/date-value.component';
-import { of, BehaviorSubject } from 'rxjs';
+import { ConvertJSONLD, CountQueryResult, ExtendedSearchParams, KuiCoreConfig, KuiCoreConfigToken, OntologyInformation, Properties, ResourceClasses, SearchParamsService, SearchService } from '@knora/core';
 import { KuiActionModule } from 'projects/knora/action/src/public_api';
+import { BehaviorSubject, of } from 'rxjs';
+import { DateValueComponent } from '../../property/date-value/date-value.component';
+import { TextValueAsHtmlComponent } from '../../property/text-value/text-value-as-html/text-value-as-html.component';
+import { GraphViewComponent } from '../graph-view/graph-view.component';
+import { GridViewComponent } from '../grid-view/grid-view.component';
+import { ListViewComponent } from '../list-view/list-view.component';
+import { TableViewComponent } from '../table-view/table-view.component';
+import { SearchResultsComponent } from './search-results.component';
 
 describe('SearchResultsComponent', () => {
     let component: SearchResultsComponent;
@@ -74,14 +63,13 @@ describe('SearchResultsComponent', () => {
                             get: (param: string) => {
                                 if (param === 'q') {
                                     return q;
-                                } else if (param == 'project') {
+                                } else if (param === 'project') {
                                     if (project !== undefined) {
                                         return project;
                                     } else {
                                         return null;
                                     }
-                                }
-                                else {
+                                } else {
                                     return mode;
                                 }
                             }
@@ -170,6 +158,9 @@ describe('SearchResultsComponent', () => {
         });
 
         it('should perform a count query', () => {
+
+            component.ngOnChanges();
+
             expect(searchServiceSpy.doExtendedSearchCountQueryCountQueryResult).toHaveBeenCalledTimes(1);
 
             expect(searchServiceSpy.doExtendedSearchCountQueryCountQueryResult).toHaveBeenCalledWith('testquery0');
@@ -178,6 +169,9 @@ describe('SearchResultsComponent', () => {
         });
 
         it('should perform a gravsearch query', () => {
+
+            component.ngOnChanges();
+
             expect(searchServiceSpy.doExtendedSearchReadResourceSequence).toHaveBeenCalledTimes(1);
 
             expect(searchServiceSpy.doExtendedSearchReadResourceSequence).toHaveBeenCalledWith('testquery0');
@@ -199,6 +193,9 @@ describe('SearchResultsComponent', () => {
         });
 
         it('should perform a count query', () => {
+
+            component.ngOnChanges();
+
             expect(searchServiceSpy.doFullTextSearchCountQueryCountQueryResult).toHaveBeenCalledTimes(1);
 
             expect(searchServiceSpy.doFullTextSearchCountQueryCountQueryResult).toHaveBeenCalledWith('test', undefined);
@@ -207,6 +204,9 @@ describe('SearchResultsComponent', () => {
         });
 
         it('should perform a fulltext query', () => {
+
+            component.ngOnChanges();
+
             expect(searchServiceSpy.doFullTextSearchReadResourceSequence).toHaveBeenCalledTimes(1);
 
             expect(searchServiceSpy.doFullTextSearchReadResourceSequence).toHaveBeenCalledWith('test', 0, undefined);
@@ -229,6 +229,9 @@ describe('SearchResultsComponent', () => {
         });
 
         it('should perform a count query', () => {
+
+            component.ngOnChanges();
+
             expect(searchServiceSpy.doFullTextSearchCountQueryCountQueryResult).toHaveBeenCalledTimes(1);
 
             expect(searchServiceSpy.doFullTextSearchCountQueryCountQueryResult).toHaveBeenCalledWith('test', { limitToProject: 'http://rdfh.ch/projects/0001' });
@@ -237,6 +240,9 @@ describe('SearchResultsComponent', () => {
         });
 
         it('should perform a fulltext query', () => {
+
+            component.ngOnChanges();
+
             expect(searchServiceSpy.doFullTextSearchReadResourceSequence).toHaveBeenCalledTimes(1);
 
             expect(searchServiceSpy.doFullTextSearchReadResourceSequence).toHaveBeenCalledWith('test', 0, { limitToProject: 'http://rdfh.ch/projects/0001' });
@@ -250,7 +256,7 @@ class MockSearchParamsService {
 
     private _currentSearchParams: BehaviorSubject<any>;
 
-    constructor() {
+    constructor () {
         this._currentSearchParams = new BehaviorSubject<ExtendedSearchParams>(new ExtendedSearchParams((offset: number) => 'testquery' + offset));
     }
 

--- a/projects/knora/viewer/src/lib/view/search-results/search-results.component.ts
+++ b/projects/knora/viewer/src/lib/view/search-results/search-results.component.ts
@@ -1,7 +1,6 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { ApiServiceError, CountQueryResult, ExtendedSearchParams, KnoraConstants, OntologyInformation, ReadResource, ReadResourcesSequence, SearchParamsService, SearchService } from '@knora/core';
-import { Subscription } from 'rxjs';
 
 /**
  * The search-results gets the search mode and parameters from routes or inputs,
@@ -13,7 +12,7 @@ import { Subscription } from 'rxjs';
     templateUrl: './search-results.component.html',
     styleUrls: ['./search-results.component.scss']
 })
-export class SearchResultsComponent implements OnInit {
+export class SearchResultsComponent implements OnInit, OnChanges {
     /**
      *
      * @param  {boolean} [complexView] If true it shows 2 ways to display the search results: list or grid.
@@ -47,7 +46,7 @@ export class SearchResultsComponent implements OnInit {
     result: ReadResource[] = [];
     ontologyInfo: OntologyInformation;
     numberOfAllResults: number;
-    rerender: boolean = false;
+    // rerender: boolean = false;
     badRequest: boolean = false;
     loading = true;
     errorMessage: ApiServiceError = new ApiServiceError();
@@ -63,6 +62,10 @@ export class SearchResultsComponent implements OnInit {
     }
 
     ngOnInit() {
+
+    }
+
+    ngOnChanges() {
         this._route.paramMap.subscribe(
             (params: Params) => {
                 // get the search mode
@@ -70,7 +73,7 @@ export class SearchResultsComponent implements OnInit {
                     this.searchMode = params.get('mode');
                 }
 
-                // get the project iri 
+                // get the project iri
                 if (params.get('project') && (this.projectIri !== decodeURIComponent(params.get('project')))) {
                     this.projectIri = decodeURIComponent(params.get('project'));
                 }
@@ -93,7 +96,7 @@ export class SearchResultsComponent implements OnInit {
                 }
 
                 // get results
-                this.rerender = true;
+                // this.rerender = true;
                 this.getResult();
             }
         );
@@ -132,13 +135,13 @@ export class SearchResultsComponent implements OnInit {
 
         // FULLTEXT SEARCH
         if (this.searchMode === 'fulltext') {
-            this.rerender = true;
+            // this.rerender = true;
             if (this.badRequest) {
                 this.errorMessage = new ApiServiceError();
                 this.errorMessage.errorInfo =
                     'A search value is expected to have at least length of 3 characters.';
                 this.loading = false;
-                this.rerender = false;
+                // this.rerender = false;
             } else {
 
                 let searchParams;
@@ -234,7 +237,7 @@ export class SearchResultsComponent implements OnInit {
         // console.log('search results', this.result);
 
         this.loading = false;
-        this.rerender = false;
+        // this.rerender = false;
     }
 
     /**


### PR DESCRIPTION
This PR fixes some issues in @knora/viewer search-results:

- Using ngOnInit instead ngOnChanges (because of this [advice](https://scotch.io/tutorials/3-ways-to-pass-async-data-to-angular-2-child-components#toc-solution-2-use-ngonchanges))
- Removed unused rerender variable (same as loading)