### PR TITLE
Support https in gravatar service

### DIFF
--- a/projects/knora/action/ng-package.json
+++ b/projects/knora/action/ng-package.json
@@ -6,7 +6,7 @@
     "entryFile": "src/public_api.ts",
     "umdModuleIds": {
       "@knora/core": "@knora/core",
-      "tsMd5": "ts-md5",
+      "ts-md5": "ts-md5",
       "jdnconvertiblecalendardateadapter": "jdnconvertiblecalendardateadapter"
     }
   }

--- a/projects/knora/action/ng-package.prod.json
+++ b/projects/knora/action/ng-package.prod.json
@@ -5,7 +5,7 @@
     "entryFile": "src/public_api.ts",
     "umdModuleIds": {
       "@knora/core": "@knora/core",
-      "tsMd5": "ts-md5",
+      "ts-md5": "ts-md5",
       "jdnconvertiblecalendardateadapter": "jdnconvertiblecalendardateadapter"
     }
   }

--- a/projects/knora/action/src/lib/admin-image/admin-image.directive.ts
+++ b/projects/knora/action/src/lib/admin-image/admin-image.directive.ts
@@ -68,7 +68,7 @@ export class AdminImageDirective implements OnChanges {
                 if (this.image === null || this.image === undefined) {
                     this.source = AdminImageConfig.defaultUser;
                 } else {
-                    this.source = 'http://www.gravatar.com/avatar/' + Md5.hashStr(this.image) + '?d=mp&s=256';
+                    this.source = location.protocol + '//www.gravatar.com/avatar/' + Md5.hashStr(this.image) + '?d=mp&s=256';
                 }
 
                 break;


### PR DESCRIPTION
Depending on the protocol of the app, we have to use the same protocol for gravatar service. This resolves the following issue:

`Mixed Content: The page at 'https://app2.test.dasch.swiss/dashboard' was loaded over HTTPS, but requested an insecure image 'http://www.gravatar.com/avatar/48d5d2d5c3c4169b1c3fa98c4aeedbd7?d=mp&s=256'. This content should also be served over HTTPS.`

Resolves #286 