### PR TITLE
Improvements on the StringLiteral Input

### DIFF
--- a/projects/knora/action/src/assets/style/action.scss
+++ b/projects/knora/action/src/assets/style/action.scss
@@ -31,7 +31,7 @@
   .mat-form-field-wrapper {
     width: 100%;
     .mat-form-field-flex {
-      padding-left: 16px !important;
+      padding-left: 12px !important;
       border-left: 1px solid rgba(0, 0, 0, 0.12);
       min-height: calc(4 * 36px + 2px);
     }

--- a/projects/knora/action/src/assets/style/action.scss
+++ b/projects/knora/action/src/assets/style/action.scss
@@ -5,14 +5,14 @@
   // select language
   .mat-button-toggle {
     height: 36px;
-    width: 36px;
+    width: 64px;
   }
 
   .mat-button-toggle-appearance-standard {
     .mat-button-toggle-label-content {
       line-height: 36px !important;
       padding: 0 !important;
-      width: 32px;
+      width: 48px;
     }
   }
 

--- a/projects/knora/action/src/assets/style/action.scss
+++ b/projects/knora/action/src/assets/style/action.scss
@@ -1,18 +1,32 @@
 // string literal textarea: overwrite material styling !important
+.string-literal.short-text {
+  .mat-button.select-lang {
+    min-width: 36px !important;
+    padding: 0 8px !important;
+    border-radius: 4px 0 0 0 !important;
+  }
+  .mat-form-field-infix {
+    margin-left: 12px;
+  }
+}
+
 .string-literal.long-text {
   display: flex;
 
   // select language
   .mat-button-toggle {
     height: 36px;
-    width: 64px;
+    width: 56px;
+
+    .mat-button-toggle-button {
+      width: 50px !important;
+    }
   }
 
   .mat-button-toggle-appearance-standard {
     .mat-button-toggle-label-content {
       line-height: 36px !important;
-      padding: 0 !important;
-      width: 48px;
+      padding: 0 8px !important;
     }
   }
 
@@ -31,9 +45,18 @@
   .mat-form-field-wrapper {
     width: 100%;
     .mat-form-field-flex {
-      padding-left: 12px !important;
+      //   padding-left: 12px !important;
       border-left: 1px solid rgba(0, 0, 0, 0.12);
       min-height: calc(4 * 36px + 2px);
+
+      .mat-form-field-infix {
+        margin-left: 12px;
+
+        // negative values are not the best choice,
+        // but with this margin the placeholder is at the
+        // same position as in the short-text input
+        margin-top: -12px;
+      }
     }
   }
 

--- a/projects/knora/action/src/lib/action.module.ts
+++ b/projects/knora/action/src/lib/action.module.ts
@@ -34,6 +34,7 @@ import { ProgressIndicatorComponent } from './progress-indicator/progress-indica
 import { ResourceDialogComponent } from './resource-dialog/resource-dialog.component';
 import { SortButtonComponent } from './sort-button/sort-button.component';
 import { StringLiteralInputComponent } from './string-literal-input/string-literal-input.component';
+import { StringifyStringLiteralPipe } from './pipes/stringify-string-literal.pipe';
 
 @NgModule({
     imports: [
@@ -61,7 +62,8 @@ import { StringLiteralInputComponent } from './string-literal-input/string-liter
         ResourceDialogComponent,
         JdnDatepickerDirective,
         MessageComponent,
-        StringLiteralInputComponent
+        StringLiteralInputComponent,
+        StringifyStringLiteralPipe
     ],
     exports: [
         ProgressIndicatorComponent,
@@ -74,7 +76,8 @@ import { StringLiteralInputComponent } from './string-literal-input/string-liter
         GndDirective,
         JdnDatepickerDirective,
         MessageComponent,
-        StringLiteralInputComponent
+        StringLiteralInputComponent,
+        StringifyStringLiteralPipe
     ]
 })
 /**

--- a/projects/knora/action/src/lib/pipes/stringify-string-literal.pipe.spec.ts
+++ b/projects/knora/action/src/lib/pipes/stringify-string-literal.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { StringifyStringLiteralPipe } from './stringify-string-literal.pipe';
+
+describe('StringifyStringLiteralPipe', () => {
+  it('create an instance', () => {
+    const pipe = new StringifyStringLiteralPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/projects/knora/action/src/lib/pipes/stringify-string-literal.pipe.ts
+++ b/projects/knora/action/src/lib/pipes/stringify-string-literal.pipe.ts
@@ -1,0 +1,22 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { StringLiteral } from '@knora/core';
+
+@Pipe({
+    name: 'stringifyStringLiteral'
+})
+export class StringifyStringLiteralPipe implements PipeTransform {
+
+    transform(value: StringLiteral[]): string {
+        let stringified: string = '';
+
+        let i = 0;
+        for (const sl of value) {
+            const delimiter = (i > 0 ? ' / ' : '');
+            stringified += delimiter + sl.value + ' (' + sl.language + ')';
+
+            i++;
+        }
+        return stringified;
+    }
+
+}

--- a/projects/knora/action/src/lib/pipes/stringify-string-literal.pipe.ts
+++ b/projects/knora/action/src/lib/pipes/stringify-string-literal.pipe.ts
@@ -2,7 +2,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 import { StringLiteral } from '@knora/core';
 
 @Pipe({
-    name: 'stringifyStringLiteral'
+    name: 'kuiStringifyStringLiteral'
 })
 export class StringifyStringLiteralPipe implements PipeTransform {
 

--- a/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.html
+++ b/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.html
@@ -25,7 +25,8 @@
         </mat-menu>
 
         <!-- input field-->
-        <input matInput [placeholder]="placeholder" [formControl]="form.controls['text']" #textInput>
+        <input matInput [placeholder]="placeholder" [formControl]="form.controls['text']" #textInput
+               (keyup.enter)="enter.emit(true)">
     </mat-form-field>
 
     <!-- input element type is textarea -->

--- a/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.html
+++ b/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.html
@@ -39,8 +39,7 @@
         </mat-button-toggle-group>
         <mat-form-field class="string-literal-textarea">
             <!-- textarea -->
-            <textarea matInput [placeholder]="placeholder + ' (' + language + ')'" [formControl]="form.controls['text']"
-                      #textInput></textarea>
+            <textarea matInput [placeholder]="placeholder" [formControl]="form.controls['text']" #textInput></textarea>
         </mat-form-field>
     </div>
 

--- a/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.html
+++ b/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.html
@@ -25,8 +25,7 @@
         </mat-menu>
 
         <!-- input field-->
-        <input matInput [placeholder]="placeholder + ' (' + language + ')'" [formControl]="form.controls['text']"
-               #textInput>
+        <input matInput [placeholder]="placeholder" [formControl]="form.controls['text']" #textInput>
     </mat-form-field>
 
     <!-- input element type is textarea -->

--- a/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.html
+++ b/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.html
@@ -26,7 +26,7 @@
 
         <!-- input field-->
         <input matInput [placeholder]="placeholder" [formControl]="form.controls['text']" #textInput
-               (keyup.enter)="enter.emit(true)">
+               [readonly]="readonly" (keyup.enter)="enter.emit(true)">
     </mat-form-field>
 
     <!-- input element type is textarea -->
@@ -40,7 +40,8 @@
         </mat-button-toggle-group>
         <mat-form-field class="string-literal-textarea">
             <!-- textarea -->
-            <textarea matInput [placeholder]="placeholder" [formControl]="form.controls['text']" #textInput></textarea>
+            <textarea matInput [placeholder]="placeholder" [formControl]="form.controls['text']" #textInput
+                      [readonly]="readonly"></textarea>
         </mat-form-field>
     </div>
 

--- a/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.ts
+++ b/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.ts
@@ -2,7 +2,6 @@ import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild }
 import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { MatMenuTrigger } from '@angular/material';
 import { StringLiteral } from '@knora/core/public_api';
-import { Placeholder } from '@angular/compiler/src/i18n/i18n_ast';
 
 @Component({
     selector: 'kui-string-literal-input',
@@ -57,6 +56,8 @@ export class StringLiteralInputComponent implements OnInit {
      */
     @Output() dataChanged: EventEmitter<StringLiteral[]> = new EventEmitter<StringLiteral[]>();
 
+    @Output() touched: EventEmitter<boolean> = new EventEmitter<boolean>();
+
     @ViewChild('textInput', { static: false }) textInput: ElementRef;
 
     @ViewChild('btnToSelectLanguage', { static: false }) btnToSelectLanguage: MatMenuTrigger;
@@ -103,7 +104,7 @@ export class StringLiteralInputComponent implements OnInit {
                     disabled: this.disabled
                 },
                 {
-                    updateOn: 'blur'
+                    // updateOn: 'blur'
                 }
             )
         });
@@ -122,10 +123,24 @@ export class StringLiteralInputComponent implements OnInit {
             return;
         }
 
+        const form = this.form;
+        const control = form.get('text');
+        this.touched.emit(control && control.dirty);
+        if (control && control.dirty) {
+            console.warn('control dirty');
+
+        }
+
         this.updateStringLiterals(this.language, this.form.controls['text'].value);
 
         this.dataChanged.emit(this.value);
 
+    }
+
+    onFocus(state: boolean) {
+        console.log('touched string literal input', state);
+        console.log('send data to parent', this.value);
+        this.touched.emit(state);
     }
 
     toggleAll() {
@@ -184,10 +199,11 @@ export class StringLiteralInputComponent implements OnInit {
         if (index < 0 && value) {
             // value doesn't exist in stringLiterals: add one
             // console.log('add new value (' + value + ') for ' + lang);
-            this.value.push({
+            const newValue: StringLiteral = {
                 language: lang,
                 value: value
-            });
+            };
+            this.value.push(newValue);
         }
 
     }

--- a/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.ts
+++ b/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.ts
@@ -50,16 +50,30 @@ export class StringLiteralInputComponent implements OnInit {
     @Input() disabled?: boolean = false;
 
     /**
-     * Returns (output) an array of StringLiteral when the focus is not anymore on the input field.
+     * The readonly attribute specifies whether the control may be modified by the user.
+     *
+     * @param {boolean}: [readonly=false]
+     */
+    @Input() readonly?: boolean = false;
+
+    /**
+     * Returns (output) an array of StringLiteral on any change on the input field.
      *
      * @emits {StringLiteral[]} dataChanged
      */
     @Output() dataChanged: EventEmitter<StringLiteral[]> = new EventEmitter<StringLiteral[]>();
 
+    /**
+     * Returns (output) true when the field was touched. This can be used to validate data, e.g. in case a value is required
+     *
+     * @emits {boolean} touched
+     */
     @Output() touched: EventEmitter<boolean> = new EventEmitter<boolean>();
 
     /**
      * Returns true when a user press ENTER. This can be used to submit data in the parent component.
+     *
+     * * @emits {boolean} enter
      */
     @Output() enter: EventEmitter<boolean> = new EventEmitter<boolean>();
 
@@ -123,6 +137,11 @@ export class StringLiteralInputComponent implements OnInit {
 
     }
 
+    /**
+     * @ignore
+     *
+     * emit data to parent on any change on the input field
+     */
     onValueChanged() {
         if (!this.form) {
             return;
@@ -143,16 +162,15 @@ export class StringLiteralInputComponent implements OnInit {
 
     }
 
-    onFocus(state: boolean) {
-        console.log('touched string literal input', state);
-        console.log('send data to parent', this.value);
-        this.touched.emit(state);
-    }
-
     toggleAll() {
         // TODO: open/show all languages with their values
     }
 
+    /**
+     * @ignore
+     *
+     * Set the language after selecting; This updates the array of StringLiterals: adds item with the selected language if it doesn't exist
+     */
     setLanguage(lang: string) {
 
         if (this.language === lang) {
@@ -168,6 +186,11 @@ export class StringLiteralInputComponent implements OnInit {
         }
     }
 
+    /**
+     * @ignore
+     *
+     * Switch focus to input field after selecting a language
+     */
     switchFocus() {
         // close the menu
         if (!this.textarea && this.btnToSelectLanguage && this.btnToSelectLanguage.menuOpen) {
@@ -180,6 +203,11 @@ export class StringLiteralInputComponent implements OnInit {
         }
     }
 
+    /**
+     * @ignore
+     *
+     * Set the value in the input field
+     */
     updateFormField(value: string) {
         if (!value) {
             value = '';
@@ -187,6 +215,11 @@ export class StringLiteralInputComponent implements OnInit {
         this.form.controls['text'].setValue(value);
     }
 
+    /**
+     * @ignore
+     *
+     * Update the array of StringLiterals depending on value / empty value add or remove item from array.
+     */
     updateStringLiterals(lang: string, value?: string) {
         const index = this.value.findIndex(i => i.language === lang);
 
@@ -214,6 +247,11 @@ export class StringLiteralInputComponent implements OnInit {
 
     }
 
+    /**
+     * @ignore
+     *
+     * In case of strange array of StringLiterals, this method will reset to a API-conform array. This means an array without empty values.
+     */
     resetValues() {
         const length: number = this.value.length;
 
@@ -237,6 +275,11 @@ export class StringLiteralInputComponent implements OnInit {
         }
     }
 
+    /**
+     * @ignore
+     *
+     * Get the value from array of StringLiterals for the selected language
+     */
     getValueFromStringLiteral(lang: string): string {
         // console.log('existing value in', this.value);
         // get index for this language

--- a/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.ts
+++ b/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.ts
@@ -126,10 +126,10 @@ export class StringLiteralInputComponent implements OnInit {
         const form = this.form;
         const control = form.get('text');
         this.touched.emit(control && control.dirty);
-        if (control && control.dirty) {
-            console.warn('control dirty');
+        // if (control && control.dirty) {
+        // console.warn('control dirty');
 
-        }
+        // }
 
         this.updateStringLiterals(this.language, this.form.controls['text'].value);
 

--- a/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.ts
+++ b/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.ts
@@ -206,8 +206,8 @@ export class StringLiteralInputComponent implements OnInit {
             // value doesn't exist in stringLiterals: add one
             // console.log('add new value (' + value + ') for ' + lang);
             const newValue: StringLiteral = {
-                language: lang,
-                value: value
+                value: value,
+                language: lang
             };
             this.value.push(newValue);
         }

--- a/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.ts
+++ b/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.ts
@@ -58,6 +58,11 @@ export class StringLiteralInputComponent implements OnInit {
 
     @Output() touched: EventEmitter<boolean> = new EventEmitter<boolean>();
 
+    /**
+     * Returns true when a user press ENTER. This can be used to submit data in the parent component.
+     */
+    @Output() enter: EventEmitter<boolean> = new EventEmitter<boolean>();
+
     @ViewChild('textInput', { static: false }) textInput: ElementRef;
 
     @ViewChild('btnToSelectLanguage', { static: false }) btnToSelectLanguage: MatMenuTrigger;
@@ -126,6 +131,7 @@ export class StringLiteralInputComponent implements OnInit {
         const form = this.form;
         const control = form.get('text');
         this.touched.emit(control && control.dirty);
+
         // if (control && control.dirty) {
         // console.warn('control dirty');
 

--- a/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.ts
+++ b/projects/knora/action/src/lib/string-literal-input/string-literal-input.component.ts
@@ -2,6 +2,7 @@ import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild }
 import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { MatMenuTrigger } from '@angular/material';
 import { StringLiteral } from '@knora/core/public_api';
+import { Placeholder } from '@angular/compiler/src/i18n/i18n_ast';
 
 @Component({
     selector: 'kui-string-literal-input',
@@ -86,6 +87,10 @@ export class StringLiteralInputComponent implements OnInit {
     }
 
     ngOnInit() {
+
+        // if (this.placeholder.length > 0) {
+        //     this.placeholder += ' (' + this.language + ')';
+        // }
 
         // reset stringLiterals if they have empty values
         this.resetValues();

--- a/projects/knora/action/src/public_api.ts
+++ b/projects/knora/action/src/public_api.ts
@@ -18,3 +18,4 @@ export * from './lib/action.module';
 export * from './lib/pipes/reverse.pipe';
 export * from './lib/pipes/key.pipe';
 export * from './lib/pipes/sort-by.pipe';
+export * from './lib/pipes/stringify-string-literal.pipe';

--- a/projects/knora/core/src/lib/services/admin/lists.service.ts
+++ b/projects/knora/core/src/lib/services/admin/lists.service.ts
@@ -123,4 +123,6 @@ export class ListsService extends ApiService {
             catchError(this.handleJsonError)
         );
     }
+
+    // updateListItem(payload: )
 }


### PR DESCRIPTION
In this PR we optimized the String Literal input component from @knora/action module. And it contains a new feature: an angular pipe to stringify an array of StringLiterals:
```typescript
labels: StringLiteral[] = [
  {
    value: "Frühling", 
    language: "de"
  },
  {
    value: "Spring",
    language: "en"
  },
  {
    value: "Printemps", 
    language: "fr"
  }
]
```

The usage in a template as `{{labels | stringifyStringLiteral}}` becomes `Frühling (de) / Spring (en) / Printemps (fr)`

